### PR TITLE
Check mandatory fields for latest item

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -25,6 +25,7 @@ object Global extends GlobalSettings {
     (new GetNonExistentContentShould404).execute
     (new PreviewContentSetNotInLiveTest).execute
     (new ValidateArticleSchema).execute
+    (new NewestItemFieldsTest).execute
   }
 
 

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.sanity
 
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, FlatSpec}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 
 class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
@@ -14,27 +14,14 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
       val newestItem = ((json \ "response" \ "results")(0))
-      val newestItemId = (newestItem \ "id").asOpt[String]
-      val mandatoryFields = List[String]("webTitle","webPublicationDate","sectionName","sectionId","id","webUrl","apiUrl")
-      for(mandatoryField <- mandatoryFields)
-        withClue (s"Mandatory field $mandatoryField for $newestItemId was not found \n") {
-          (newestItem \ mandatoryField).asOpt[String] should be (defined)
-          (newestItem \ mandatoryField).asOpt[String] should not be empty
-        }
-      val headline = (newestItem \ "fields" \ "headline").asOpt[String]
-      withClue (s"Mandatory field headline for $newestItemId was not found \n") {
-        headline should be (defined)
-        headline should not be empty
-      }
-
       val newestItemFirstTag = (newestItem \ "tags")(0)
-      val tagMandatoryFields = List("id","webTitle","type","sectionId","sectionName","webUrl","apiUrl")
-      for(tagMandatoryField <- tagMandatoryFields)
-        withClue (s"Mandatory tag field $tagMandatoryField for $newestItemId was not found \n") {
-          (newestItemFirstTag \ tagMandatoryField).asOpt[String] should be (defined)
-          (newestItemFirstTag \ tagMandatoryField).asOpt[String] should not be empty
+      val newestItemId = (newestItem \ "id").asOpt[String].getOrElse("ID not found")
+      val mandatoryFields = List[JsValue] (newestItem\"webTitle",newestItem\"sectionName",newestItem\"sectionId",newestItem\"id",newestItem\"webUrl",newestItem\"id",newestItem\"webUrl",newestItem\"apiUrl",newestItemFirstTag\"id",newestItemFirstTag\"webTitle",newestItemFirstTag\"type",newestItemFirstTag\"sectionId",newestItemFirstTag\"sectionName",newestItemFirstTag\"webUrl",newestItemFirstTag\"apiUrl",newestItem\"fields"\"headline")
+      for(mandatoryField <- mandatoryFields)
+        withClue (s"Mandatory field not found! $mandatoryField for ID: $newestItemId") {
+          (mandatoryField).asOpt[String] should be (defined)
+          (mandatoryField).asOpt[String] should not be empty
         }
-
     }
   }(fail,testNames.head, tags)
  }

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -16,7 +16,9 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
       val newestItem = ((json \ "response" \ "results")(0))
       val newestItemFirstTag = (newestItem \ "tags")(0)
       val newestItemId = (newestItem \ "id").asOpt[String].getOrElse("ID not found")
-      val mandatoryFields = List[JsValue] (newestItem\"webTitle",newestItem\"sectionName",newestItem\"sectionId",newestItem\"id",newestItem\"webUrl",newestItem\"id",newestItem\"webUrl",newestItem\"apiUrl",newestItemFirstTag\"id",newestItemFirstTag\"webTitle",newestItemFirstTag\"type",newestItemFirstTag\"sectionId",newestItemFirstTag\"sectionName",newestItemFirstTag\"webUrl",newestItemFirstTag\"apiUrl",newestItem\"fields"\"headline")
+      val mandatoryFields = List[JsValue] (newestItem\"webTitle",newestItem\"sectionName",newestItem\"sectionId",newestItem\"id",newestItem\"webUrl",newestItem\"apiUrl",
+        newestItemFirstTag\"id",newestItemFirstTag\"webTitle",newestItemFirstTag\"type",newestItemFirstTag\"sectionId",newestItemFirstTag\"sectionName",newestItemFirstTag\"webUrl",newestItemFirstTag\"apiUrl",
+        newestItem\"fields"\"headline")
       for(mandatoryField <- mandatoryFields)
         withClue (s"Mandatory field not found! $mandatoryField for ID: $newestItemId") {
           (mandatoryField).asOpt[String] should be (defined)

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -9,20 +9,33 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
   "The newest item" should "include mandatory fields" taggedAs(FrequentTest, PRODTest)  in {
 
     handleException {
-      val httpRequest = requestHost("search?order-by=newest").get
-      whenReady(httpRequest) { result =>
-        assume(result.status == 200, "Service is down")
-        val json = Json.parse(result.body)
-        val newestItem = (json \ "response" \ "results")(0)
-        val mandatoryFields = List("webTitle","webPublicationDate","sectionName","sectionId","id","webUrl","apiUrl")
-        for(mandatoryField <- mandatoryFields)
-        withClue (s"Mandatory field $mandatoryField was not found \n") {
+      val httpRequest = requestHost("search?order-by=newest&show-tags=all&show-fields=headline").get
+    whenReady(httpRequest) { result =>
+      assume(result.status == 200, "Service is down")
+      val json = Json.parse(result.body)
+      val newestItem = ((json \ "response" \ "results")(0))
+      val newestItemId = (newestItem \ "id").asOpt[String]
+      val mandatoryFields = List[String]("webTitle","webPublicationDate","sectionName","sectionId","id","webUrl","apiUrl")
+      for(mandatoryField <- mandatoryFields)
+        withClue (s"Mandatory field $mandatoryField for $newestItemId was not found \n") {
           (newestItem \ mandatoryField).asOpt[String] should be (defined)
           (newestItem \ mandatoryField).asOpt[String] should not be empty
         }
+      val headline = (newestItem \ "fields" \ "headline").asOpt[String]
+      withClue (s"Mandatory field headline for $newestItemId was not found \n") {
+        headline should be (defined)
+        headline should not be empty
       }
-    }(fail,testNames.head, tags)
-  }
 
+      val newestItemFirstTag = (newestItem \ "tags")(0)
+      val tagMandatoryFields = List("id","webTitle","type","sectionId","sectionName","webUrl","apiUrl")
+      for(tagMandatoryField <- tagMandatoryFields)
+        withClue (s"Mandatory tag field $tagMandatoryField for $newestItemId was not found \n") {
+          (newestItemFirstTag \ tagMandatoryField).asOpt[String] should be (defined)
+          (newestItemFirstTag \ tagMandatoryField).asOpt[String] should not be empty
+        }
 
+    }
+  }(fail,testNames.head, tags)
+ }
 }

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -9,7 +9,7 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
   "The newest item" should "include mandatory fields" taggedAs(FrequentTest, PRODTest)  in {
 
     handleException {
-      val httpRequest = requestHost("search?order-by=newest&show-tags=all&show-fields=headline").get
+      val httpRequest = requestHost("search?order-by=newest&show-tags=all").get
     whenReady(httpRequest) { result =>
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
@@ -17,8 +17,7 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
       val newestItemFirstTag = (newestItem \ "tags")(0)
       val newestItemId = (newestItem \ "id").asOpt[String].getOrElse("ID not found")
       val mandatoryFields = List[JsValue] (newestItem\"webTitle",newestItem\"sectionName",newestItem\"sectionId",newestItem\"id",newestItem\"webUrl",newestItem\"apiUrl",
-        newestItemFirstTag\"id",newestItemFirstTag\"webTitle",newestItemFirstTag\"type",newestItemFirstTag\"sectionId",newestItemFirstTag\"sectionName",newestItemFirstTag\"webUrl",newestItemFirstTag\"apiUrl",
-        newestItem\"fields"\"headline")
+        newestItemFirstTag\"id",newestItemFirstTag\"webTitle",newestItemFirstTag\"type",newestItemFirstTag\"sectionId",newestItemFirstTag\"sectionName",newestItemFirstTag\"webUrl",newestItemFirstTag\"apiUrl")
       for(mandatoryField <- mandatoryFields)
         withClue (s"Mandatory field not found! $mandatoryField for ID: $newestItemId") {
           (mandatoryField).asOpt[String] should be (defined)

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -1,0 +1,28 @@
+package com.gu.contentapi.sanity
+
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{Matchers, FlatSpec}
+import play.api.libs.json.Json
+
+class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
+
+  "The newest item" should "include mandatory fields" taggedAs(FrequentTest, PRODTest)  in {
+
+    handleException {
+      val httpRequest = requestHost("search?order-by=newest").get
+      whenReady(httpRequest) { result =>
+        assume(result.status == 200, "Service is down")
+        val json = Json.parse(result.body)
+        val newestItem = (json \ "response" \ "results")(0)
+        val mandatoryFields = List("webTitle","webPublicationDate","sectionName","sectionId","id","webUrl","apiUrl")
+        for(mandatoryField <- mandatoryFields)
+        withClue (s"Mandatory field $mandatoryField was not found \n") {
+          (newestItem \ mandatoryField).asOpt[String] should be (defined)
+          (newestItem \ mandatoryField).asOpt[String] should not be empty
+        }
+      }
+    }(fail,testNames.head, tags)
+  }
+
+
+}

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -16,8 +16,21 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
       val newestItem = ((json \ "response" \ "results")(0))
       val newestItemFirstTag = (newestItem \ "tags")(0)
       val newestItemId = (newestItem \ "id").asOpt[String].getOrElse("ID not found")
-      val mandatoryFields = List[JsValue] (newestItem\"webTitle",newestItem\"sectionName",newestItem\"sectionId",newestItem\"id",newestItem\"webUrl",newestItem\"apiUrl",
-        newestItemFirstTag\"id",newestItemFirstTag\"webTitle",newestItemFirstTag\"type",newestItemFirstTag\"sectionId",newestItemFirstTag\"sectionName",newestItemFirstTag\"webUrl",newestItemFirstTag\"apiUrl")
+      val mandatoryFields = List[JsValue] (
+        newestItem\"webTitle",
+        newestItem\"sectionName",
+        newestItem\"sectionId",
+        newestItem\"id",
+        newestItem\"webUrl",
+        newestItem\"apiUrl",
+        newestItemFirstTag\"id",
+        newestItemFirstTag\"webTitle",
+        newestItemFirstTag\"type",
+        newestItemFirstTag\"sectionId",
+        newestItemFirstTag\"sectionName",
+        newestItemFirstTag\"webUrl",
+        newestItemFirstTag\"apiUrl")
+
       for(mandatoryField <- mandatoryFields)
         withClue (s"Mandatory field not found! $mandatoryField for ID: $newestItemId") {
           (mandatoryField).asOpt[String] should be (defined)


### PR DESCRIPTION
Adding a test that mandatory fields should be visible on the newest item. To catch the case where either we remove a mandatory field or it starts coming back as empty. I am also checking there is at least 1 tag on that item and that tag contains mandatory fields. If anyone in @guardian/content-platforms knows any more fields which are mandatory do say and I can add them to the list. 