### PR TITLE
add test for most viewed

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -25,6 +25,7 @@ object Global extends GlobalSettings {
     (new GetNonExistentContentShould404).execute
     (new PreviewContentSetNotInLiveTest).execute
     (new ValidateArticleSchema).execute
+    (new MostViewedContainsItemsTest).execute
   }
 
 

--- a/app/MostViewedContainsItemsTest.scala
+++ b/app/MostViewedContainsItemsTest.scala
@@ -1,0 +1,23 @@
+import com.gu.contentapi.sanity._
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{Matchers, FlatSpec}
+import play.api.libs.json.Json
+
+class MostViewedContainsItemsTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
+
+  "Most Viewed" should "contain 20 items" taggedAs(FrequentTest, PRODTest)  in {
+
+    handleException {
+      val httpRequest = requestHost("/uk?show-most-viewed=true").get
+      whenReady(httpRequest) { result =>
+        assume(result.status == 200, "Service is down")
+        val json = Json.parse(result.body)
+        val mostViewedJson = (json \ "response" \ "mostViewed")
+        val mostViewedList = mostViewedJson.as[List[Map[String, String]]]
+        mostViewedList.length should be (20)
+      }
+    }(fail,testNames.head, tags)
+  }
+
+}
+


### PR DESCRIPTION
Most viewed should contain 20 items. To catch recent regression where most viewed was empty.
CC @mchv @guardian/content-platforms 