### PR TITLE
Crossword test

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -27,6 +27,7 @@ object Global extends GlobalSettings {
     (new ValidateArticleSchema).execute
     (new NewestItemFieldsTest).execute
     (new MostViewedContainsItemsTest).execute
+    (new CrosswordsIndexingTest).execute
   }
 
 

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -27,7 +27,6 @@ object Global extends GlobalSettings {
     (new ValidateArticleSchema).execute
     (new NewestItemFieldsTest).execute
     (new MostViewedContainsItemsTest).execute
-    (new CrosswordsIndexingTest).execute
   }
 
 

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -9,7 +9,7 @@ object Global extends GlobalSettings {
     Logger.info("Application has started")
     QuartzScheduler.start()
     QuartzScheduler schedule("Frequent Tests", runFrequentTests) every (30 seconds)
-    QuartzScheduler schedule("Infrequent Tests", runInfrequentTests) at "0 0 12 ? * MON-FRI *"
+    QuartzScheduler schedule("Infrequent Tests", runInfrequentTests) at "0 0 9 ? * MON-FRI *"
   }
 
   override def onStop(app: Application) {
@@ -27,6 +27,7 @@ object Global extends GlobalSettings {
     (new ValidateArticleSchema).execute
     (new NewestItemFieldsTest).execute
     (new MostViewedContainsItemsTest).execute
+    (new CrosswordsIndexingTest).execute
   }
 
 
@@ -34,6 +35,7 @@ object Global extends GlobalSettings {
   def runInfrequentTests {
     (new JREVersionTest).execute
     (new AmiSanityTest).execute
+    (new CrosswordsIndexingTest).execute
   }
 
 }

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -4,6 +4,7 @@ import org.joda.time.{DateTime}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, FlatSpec}
 import play.api.libs.json.{JsValue, Json}
+import org.scalatest.OptionValues._
 
 class CrosswordsIndexingTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
@@ -24,8 +25,8 @@ class CrosswordsIndexingTest extends FlatSpec with Matchers with ScalaFutures wi
           newestItemOpt should be (defined)
         }
         newestItemOpt foreach { newestItem =>
-          val newestItemDateString = (newestItem \ "webPublicationDate").as[String]
-          val newestItemDate = DateTime.parse(newestItemDateString)
+          val newestItemDateString = (newestItem \ "webPublicationDate").asOpt[String]
+          val newestItemDate = DateTime.parse(newestItemDateString.value)
           withClue(s"Latest indexed crossword was at $newestItemDate which is more than 25 hours ago ($twentyFiveHoursAgo)") {
             newestItemDate.isAfter(twentyFiveHoursAgo) should be(true)
           }

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -1,0 +1,34 @@
+package com.gu.contentapi.sanity
+
+import java.text.SimpleDateFormat
+
+import org.joda.time.{LocalDate, DateTime}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{Matchers, FlatSpec}
+import play.api.libs.json.Json
+
+class CrosswordsIndexingTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
+
+  "A new Crossword" should "be indexed every day" taggedAs(LowPriorityTest, PRODTest) in {
+
+    handleException {
+      val now = DateTime.now
+      val isAfterChristmas = now.getMonthOfYear == 12 && (now.getDayOfMonth == 26 || now.getDayOfMonth == 27)
+      val twentyFiveHoursAgo = now.minusHours(25)
+      val httpRequest = requestHost("search?tag=type/crossword&order-by=newest").get
+      whenReady(httpRequest) { result =>
+        assume(result.status == 200, "Service is down")
+        val json = Json.parse(result.body)
+        val newestItem = (json \ "response" \ "results")(0)
+        val newestItemDateString = (newestItem \ "webPublicationDate").as[String]
+        val newestItemDate = DateTime.parse(newestItemDateString)
+        assume(!isAfterChristmas, "Cancelling as Crosswords are not always published over the Christmas period")
+        withClue(s"Latest indexed crossword was at $newestItemDate which is more than 25 hours ago ($twentyFiveHoursAgo)") {
+          newestItemDate.isAfter(twentyFiveHoursAgo) should be(true)
+        }
+      }
+    }(fail, testNames.head, tags)
+  }
+}
+
+

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -1,8 +1,6 @@
 package com.gu.contentapi.sanity
 
-import java.text.SimpleDateFormat
-
-import org.joda.time.{LocalDate, DateTime}
+import org.joda.time.{DateTime}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, FlatSpec}
 import play.api.libs.json.Json

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -13,6 +13,8 @@ class CrosswordsIndexingTest extends FlatSpec with Matchers with ScalaFutures wi
       val now = DateTime.now
       val isAfterChristmas = now.getMonthOfYear == 12 && (now.getDayOfMonth == 26 || now.getDayOfMonth == 27)
       val twentyFiveHoursAgo = now.minusHours(25)
+      assume(!isAfterChristmas, "Cancelling as Crosswords are not always published over the Christmas period")
+
       val httpRequest = requestHost("search?tag=type/crossword&order-by=newest").get
       whenReady(httpRequest) { result =>
         assume(result.status == 200, "Service is down")
@@ -20,7 +22,6 @@ class CrosswordsIndexingTest extends FlatSpec with Matchers with ScalaFutures wi
         val newestItem = (json \ "response" \ "results")(0)
         val newestItemDateString = (newestItem \ "webPublicationDate").as[String]
         val newestItemDate = DateTime.parse(newestItemDateString)
-        assume(!isAfterChristmas, "Cancelling as Crosswords are not always published over the Christmas period")
         withClue(s"Latest indexed crossword was at $newestItemDate which is more than 25 hours ago ($twentyFiveHoursAgo)") {
           newestItemDate.isAfter(twentyFiveHoursAgo) should be(true)
         }

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.4"
 
 libraryDependencies += "org.seleniumhq.selenium" % "selenium-java" % "2.41.0"
 
-libraryDependencies += "joda-time" % "joda-time" % "2.4"
+libraryDependencies += "joda-time" % "joda-time" % "2.7"
 
 libraryDependencies += ws
 


### PR DESCRIPTION
Add a new low priority test to check we are indexing crosswords. (To catch recent regression where this was failing).

I assert there has to have been a new crossword within 25 hours to give some grace in case the crossword is not published exactly at midnight. Also I exclude the days after Christmas and Boxing Day as we do not always publish a crossword on those days.

Also changed the Low Priority tests to run at 9am rather than midday.
CC @guardian/content-platforms 