### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,39 @@ Simple set of sanity test for things like the AMI version.
 ## Config
 In the `conf` folder edit the `application.conf.sample` file with your own values and rename to `application.conf`.
 
-## Running
+## Note: Separation of Internal and External facing tests
 
-## Run as a scheduled service
-``sbt start``
+The tests are split into two types. __Internal facing tests__ rely on endpoints that are only accessible from within the Guardian network . __External facing tests__  are tests using only internet accessible endpoints.
 
-### Run all tests
+### Internal facing tests
+Internal facing tests are run using the sbt `test` command.
+
+#### Run all internal facing tests locally
 ``sbt clean test``
 
-### Run tests with a specific tag
+#### Run internal facing tests with a specific tag locally
 ``sbt "test-only -- -n InfrequentTest"``
 
+#### Running remotely
+The tests can be run in TeamCity by creating a build which runs `sbt test`
 
+#### Adding a test
+Add it to the `test` source root with a filename ending in `Test`
+
+### External facing tests
+External facing tests are run as a scheduled service started by the sbt `start` command.              
+
+#### Run all external facing tests locally
+`sbt start` 
+
+#### Running remotely
+Deploy the `sanity-tests` project from Riff-Raff.
+Once deployed the tests run on a regular schedule in EC2.
+
+#### Adding a test
+Add it to the `app` source root and to `global.scala`
+
+-----------
 
 > __canary in a coal mine__ (plural __canaries in a coal mine__)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Deploy the `sanity-tests` project from Riff-Raff.
 Once deployed the tests run on a regular schedule in EC2.
 
 #### Adding a test
-Add it to the `app` source root and to `global.scala`
+Add it to the `app` source root and to `Global.scala`
 
 -----------
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The tests are split into two types. __Internal facing tests__ rely on endpoints 
 ### Internal facing tests
 Internal facing tests are run using the sbt `test` command.
 
-#### Run all internal facing tests locally
+#### Run all tests locally
 ``sbt clean test``
 
-#### Run internal facing tests with a specific tag locally
+#### Run tests with a specific tag locally
 ``sbt "test-only -- -n InfrequentTest"``
 
 #### Running remotely
@@ -22,10 +22,12 @@ The tests can be run in TeamCity by creating a build which runs `sbt test`
 #### Adding a test
 Add it to the `test` source root with a filename ending in `Test`
 
+-----------------
+
 ### External facing tests
 External facing tests are run as a scheduled service started by the sbt `start` command.              
 
-#### Run all external facing tests locally
+#### Run all tests locally
 `sbt start` 
 
 #### Running remotely


### PR DESCRIPTION
Update readme to make clearer separation between internal and external tests. Also steps to adding new tests.

CC @guardian/content-platforms 