### PR TITLE
Check public hosts' SSL expiry

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -34,6 +34,7 @@ object Global extends GlobalSettings {
   def runInfrequentTests {
     (new JREVersionTest).execute
     (new AmiSanityTest).execute
+    (new SSLExpiryTest).execute
   }
 
 }

--- a/app/com/gu/contentapi/sanity/Config.scala
+++ b/app/com/gu/contentapi/sanity/Config.scala
@@ -10,6 +10,7 @@ object Config {
   conf.checkValid(ConfigFactory.defaultReference(), "content-api-sanity-code")
 
   val host = sanityConfig.getString("host")
+  val hostPublicSecure = sanityConfig.getString("host-public-secure")
   val r2AdminHost = sanityCodeConfig.getString("r2-admin-host")
   val r2AdminUsername = sanityCodeConfig.getString("r2-admin-username")
   val r2AdminPassword = sanityCodeConfig.getString("r2-admin-password")
@@ -19,6 +20,7 @@ object Config {
   val apiKey = sanityConfig.getString("api-key")
   val previewHost = sanityConfig.getString("preview-host")
   val writeHost = sanityConfig.getString("write-host")
+  val writePreviewHost = sanityConfig.getString("write-preview-host")
   val writeUsername = sanityConfig.getString("write-username")
   val writePassword = sanityConfig.getString("write-password")
   val pagerDutyServiceKey=sanityConfig.getString("pager-duty-service-key")

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -43,7 +43,11 @@ class SSLExpiryTest extends FlatSpec with ScalaFutures with IntegrationPatience 
 
         certsTry match {
           case Success(certs) =>
+            withClue(s"No Certificates found for $host") {
+              certs.length should be >= 1
+            }
             certs.headOption.map { cert =>
+              cert shouldBe a[X509CertImpl]
               val x = cert.asInstanceOf[X509CertImpl]
               val expiry = x.getNotAfter.getTime
               val daysleft = Days.daysBetween(new DateTime(), new DateTime(expiry.toLong)).getDays

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -12,7 +12,7 @@ import scala.util.Try
 
 class SSLExpiryTest extends FlatSpec with ScalaFutures with IntegrationPatience {
 
-  "SSL Certificates" should "be more than 30 days from expiry"/* taggedAs (LowPriorityTest)*/ in {
+  "SSL Certificates" should "be more than 30 days from expiry" taggedAs (LowPriorityTest) in {
     handleException {
       val hosts = Seq(
         Config.host,

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -1,0 +1,63 @@
+package com.gu.contentapi.sanity
+
+import org.scalatest.{FlatSpec}
+import javax.net.ssl._
+import java.net.{ProtocolException, MalformedURLException, URL}
+import org.joda.time.{Days, DateTime}
+import java.io.IOException
+import sun.security.x509.X509CertImpl
+
+class SSLExpiryTest extends FlatSpec {
+
+  "SSL Certificates" should "be more than 30 days from expiry" taggedAs(LowPriorityTest) in {
+    handleException {
+      val hosts = Seq (
+        Config.host,
+        Config.hostPublicSecure,
+        Config.previewHost,
+        Config.writeHost,
+        Config.writePreviewHost
+      )
+
+      val secureHosts = for (host <- hosts) yield host.replaceAll("http://", "https://")
+
+      for (host <- secureHosts) {
+        try {
+          val url = new URL(host)
+          val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
+          conn.setHostnameVerifier(new HostnameVerifier {
+            override def verify(hostnameVerifier: String, sslSession: SSLSession) = true
+          }
+          )
+          conn.connect()
+          val certs = conn.getServerCertificates
+          certs.headOption.map { cert =>
+            val x = cert.asInstanceOf[X509CertImpl]
+            val expiry = x.getNotAfter.getTime
+            val daysleft = Days.daysBetween(new DateTime(), new DateTime(expiry.toLong)).getDays
+            if (daysleft < 30) {
+              fail("Cert for %s expires in %d days".format(host, daysleft))
+            }
+          }
+          conn.disconnect()
+        } catch {
+          case e: MalformedURLException => {
+            fail("Malformed url exception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
+          }
+          case e: ProtocolException => {
+            fail("Protocol exception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
+          }
+          case e: IllegalStateException => {
+            fail("IllegalStateException exception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
+          }
+          case e: NullPointerException => {
+            fail("NullPointerException attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
+          }
+          case e: IOException => {
+            fail("IOexception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
+          }
+        }
+      }
+    }  (fail,testNames.head, tags)
+  }
+}

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -1,17 +1,20 @@
 package com.gu.contentapi.sanity
 
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import scala.util.{Try, Success, Failure}
 import org.scalatest.{FlatSpec}
 import javax.net.ssl._
-import java.net.{ProtocolException, MalformedURLException, URL}
+import java.net.{URL}
 import org.joda.time.{Days, DateTime}
-import java.io.IOException
 import sun.security.x509.X509CertImpl
 
-class SSLExpiryTest extends FlatSpec {
+import scala.util.Try
 
-  "SSL Certificates" should "be more than 30 days from expiry" taggedAs(LowPriorityTest) in {
+class SSLExpiryTest extends FlatSpec with ScalaFutures with IntegrationPatience {
+
+  "SSL Certificates" should "be more than 30 days from expiry"/* taggedAs (LowPriorityTest)*/ in {
     handleException {
-      val hosts = Seq (
+      val hosts = Seq(
         Config.host,
         Config.hostPublicSecure,
         Config.previewHost,
@@ -19,45 +22,41 @@ class SSLExpiryTest extends FlatSpec {
         Config.writePreviewHost
       )
 
-      val secureHosts = for (host <- hosts) yield host.replaceAll("http://", "https://")
+      val secureHosts = hosts map {
+        _.replaceAll("http://", "https://")
+      }
 
       for (host <- secureHosts) {
-        try {
-          val url = new URL(host)
-          val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
-          conn.setHostnameVerifier(new HostnameVerifier {
-            override def verify(hostnameVerifier: String, sslSession: SSLSession) = true
-          }
-          )
-          conn.connect()
-          val certs = conn.getServerCertificates
-          certs.headOption.map { cert =>
-            val x = cert.asInstanceOf[X509CertImpl]
-            val expiry = x.getNotAfter.getTime
-            val daysleft = Days.daysBetween(new DateTime(), new DateTime(expiry.toLong)).getDays
-            if (daysleft < 30) {
-              fail("Cert for %s expires in %d days".format(host, daysleft))
-            }
-          }
-          conn.disconnect()
-        } catch {
-          case e: MalformedURLException => {
-            fail("Malformed url exception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
-          }
-          case e: ProtocolException => {
-            fail("Protocol exception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
-          }
-          case e: IllegalStateException => {
-            fail("IllegalStateException exception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
-          }
-          case e: NullPointerException => {
-            fail("NullPointerException attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
-          }
-          case e: IOException => {
-            fail("IOexception attempting to check ssl cert for %s, exception: %s".format(host, e.getMessage))
-          }
+
+        val url = new URL(host)
+        val conn = url.openConnection().asInstanceOf[HttpsURLConnection]
+        conn.setHostnameVerifier(new HostnameVerifier {
+          override def verify(hostnameVerifier: String, sslSession: SSLSession) = true
         }
+        )
+
+        val certsTry = Try {
+          conn.connect()
+          conn.getServerCertificates
+        }
+        conn.disconnect()
+
+        certsTry match {
+          case Success(certs) =>
+            certs.headOption.map { cert =>
+              val x = cert.asInstanceOf[X509CertImpl]
+              val expiry = x.getNotAfter.getTime
+              val daysleft = Days.daysBetween(new DateTime(), new DateTime(expiry.toLong)).getDays
+              if (daysleft < 30) {
+                fail("Cert for %s expires in %d days".format(host, daysleft))
+              }
+            }
+          case Failure(e) =>
+            cancel(s"Cancelling test as exception thrown: ${e.getClass.getSimpleName}")
+
+        }
+
       }
-    }  (fail,testNames.head, tags)
+    } (fail, testNames.head, tags)
   }
 }

--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -11,6 +11,9 @@
         "host": {
             "Type": "String"
         },
+        "hostPublicSecure": {
+            "Type": "String"
+        },
         "previewHost": {
             "Type": "String"
         },
@@ -18,6 +21,9 @@
             "Type": "String"
         },
         "writeHost": {
+            "Type": "String"
+        },
+        "writePreviewHost": {
             "Type": "String"
         },
         "writeUsername": {
@@ -148,9 +154,11 @@
                             "cat > /etc/gu/content-api-sanity-tests.conf <<EOF",
                             "content-api-sanity-tests {",
                             { "Fn::Join": [ "", [ "host=\"", { "Ref": "host" },"\"" ] ] },
+                            { "Fn::Join": [ "", [ "host-public-secure=\"", { "Ref": "hostPublicSecure" },"\"" ] ] },
                             { "Fn::Join": [ "", [ "preview-host=\"", { "Ref": "previewHost" },"\"" ] ] },
                             { "Fn::Join": [ "", [ "api-key=\"", { "Ref": "apiKey" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "write-host=\"", { "Ref": "writeHost" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "write-preview-host=\"", { "Ref": "writePreviewHost" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "write-username=\"", { "Ref": "writeUsername" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "write-password=\"", { "Ref": "writePassword" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "pager-duty-service-key=\"", { "Ref": "pagerDutyServiceKey" },"\""  ] ] },

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -5,9 +5,11 @@ ws.compressionEnable=true
 # rename this to application.conf with real values
 content-api-sanity-tests {
     host="http://your-capi-host"
+    host-public-secure="https://your-public-secure-host"
     api-key=your-capi-key
     preview-host="http://your-preview-host"
-    write-host="your-write-host"
+    write-host="https://your-write-host"
+    write-preview-host="https://your-write-preview-host"
     write-username=your-write-username
     write-password=your-write-password
     pager-duty-service-key=your-pager-duty-service-key


### PR DESCRIPTION
Code borrowed from https://github.com/guardian/frontend/blob/master/integrated-tests/src/test/scala/common/SslCertTest.scala 

I have not included development environment certificates as it would involve a load of hassle to import the GNM Cert into the Trusted Certificate Store.

CC @guardian/content-platforms 