### PR TITLE
Json as option

### DIFF
--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -3,6 +3,7 @@ package com.gu.contentapi.sanity
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, FlatSpec}
 import play.api.libs.json.{JsValue, Json}
+import org.scalatest.OptionValues._
 
 class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
@@ -29,8 +30,8 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
       whenReady(httpRequest) { result =>
         assume(result.status == 200, "Service is down")
         val json = Json.parse(result.body)
-        val newestItemList = (json \ "response" \ "results").as[List[Map[String, JsValue]]]
-        for (item <- newestItemList) {
+        val newestItemList = (json \ "response" \ "results").asOpt[List[Map[String, JsValue]]]
+        for (item <- newestItemList.value) {
           val id = item.getOrElse("id", "ID for item was missing")
 
           for (mandatoryField <- mandatoryItemFields) {
@@ -39,12 +40,12 @@ class NewestItemFieldsTest extends FlatSpec with Matchers with ScalaFutures with
             }
           }
 
-          val tags = item.get("tags").get
-          val firstTag = tags(0)
-          val firstTagList = firstTag.as[Map[String, String]]
+          val tags = item.get("tags").value
+          val firstTag = tags(0).asOpt[JsValue]
+          val firstTagList = firstTag.value.asOpt[Map[String, String]]
           for (mandatoryTagField <- mandatoryTagFields) {
             withClue( s"""Mandatory tag field not found! "$mandatoryTagField" for item: $id""") {
-              firstTagList.contains(mandatoryTagField) should be (true)
+              firstTagList.value.contains(mandatoryTagField) should be (true)
             }
           }
         }

--- a/app/com/gu/contentapi/sanity/PreviewContentSetNotInLiveTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewContentSetNotInLiveTest.scala
@@ -3,6 +3,7 @@ package com.gu.contentapi.sanity
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.Json
+import org.scalatest.OptionValues._
 
 
 class PreviewContentSetNotInLiveTest extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
@@ -14,9 +15,9 @@ class PreviewContentSetNotInLiveTest extends FlatSpec with Matchers with ScalaFu
       whenReady(httpRequest) { result =>
         assume(result.status == 200, "Service is down")
         val json = Json.parse(result.body)
-        val total = (json \ "response" \ "total").as[Long]
+        val total = (json \ "response" \ "total").asOpt[Long]
         val results = Json.stringify(json \ "response" \ "results")
-        total should equal(0)
+        total.value should equal(0)
         results should equal("[]")
       }
     }(fail, testNames.head, tags)

--- a/app/com/gu/contentapi/sanity/SearchContainsLargeNumberOfResults.scala
+++ b/app/com/gu/contentapi/sanity/SearchContainsLargeNumberOfResults.scala
@@ -3,6 +3,7 @@ package com.gu.contentapi.sanity
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, FlatSpec}
 import play.api.libs.json.Json
+import org.scalatest.OptionValues._
 
 class SearchContainsLargeNumberOfResults extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
@@ -13,8 +14,8 @@ class SearchContainsLargeNumberOfResults extends FlatSpec with Matchers with Sca
       whenReady(httpRequest) { result =>
         assume(result.status == 200, "Service is down")
         val json = Json.parse(result.body)
-        val resultTotal = (json \ "response" \ "total").as[Int]
-        resultTotal should be >= 1819326
+        val resultTotal = (json \ "response" \ "total").asOpt[Int]
+        resultTotal.value should be >= 1819326
       }
     }(fail,testNames.head, tags)
   }

--- a/app/com/gu/contentapi/sanity/ValidateArticleSchema.scala
+++ b/app/com/gu/contentapi/sanity/ValidateArticleSchema.scala
@@ -3,6 +3,7 @@ package com.gu.contentapi.sanity
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, FlatSpec}
 import play.api.libs.json.Json
+import org.scalatest.OptionValues._
 
 class ValidateArticleSchema extends FlatSpec with Matchers with ScalaFutures with IntegrationPatience {
 
@@ -13,12 +14,12 @@ class ValidateArticleSchema extends FlatSpec with Matchers with ScalaFutures wit
       whenReady(httpRequest) { result =>
         assume(result.status == 200, "Service is down")
         val json = Json.parse(result.body)
-        val sectionName = (json \ "response" \ "content" \ "sectionName").as[String]
-        sectionName should be ("Life and style")
-        val headline = (json \ "response" \ "content" \ "fields" \ "headline").as[String]
-        headline should be ("Charlotte Crosby: a blueprint for civilisation")
-        val mediaId = ((json \ "response" \ "content" \ "elements")(0) \\ "mediaId")
-        mediaId shouldBe a [List[_]]
+        val sectionName = (json \ "response" \ "content" \ "sectionName").asOpt[String]
+        sectionName.value should be ("Life and style")
+        val headline = (json \ "response" \ "content" \ "fields" \ "headline").asOpt[String]
+        headline.value should be ("Charlotte Crosby: a blueprint for civilisation")
+        val mediaId = Option(((json \ "response" \ "content" \ "elements")(0) \\ "mediaId"))
+        mediaId.value shouldBe a [List[_]]
       }
     }(fail,testNames.head, tags)
   }


### PR DESCRIPTION
Wraps JSON parsing requests in an Option and uses ScalaTest [OptionValues](http://www.artima.com/docs-scalatest-2.0.M5/org/scalatest/OptionValues.html) to either get the expected value or throw `TestFailedException`.

This should correctly catch test failures where the JSON follows an unexpected structure.

CC @guardian/content-platforms @mchv @Nick-Smith 