### PR TITLE
enable plugin in cloudformation

### DIFF
--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -196,6 +196,7 @@
                             { "Fn::Join": [ "", [ "r2-admin-password=\"", { "Ref": "codeR2AdminPassword" },"\""  ] ] },
                             "}",
                             "ws.compressionEnabled=true",
+                            "ws.ning.maximumConnectionLifeTime = 60000",
                             "EOF",
                             "start sanity-tests"
                         ] ]


### PR DESCRIPTION
Aha, I think this is why Sanity Tests was not respecting TTL. It was added to the sample file but not the conf file that is in EC2.
CC @cb372 