### PR TITLE
Remove waits before retrying

### DIFF
--- a/app/com/gu/contentapi/sanity/CanaryWritingSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryWritingSanityTest.scala
@@ -23,7 +23,7 @@ class CanaryWritingSanityTest(testFailureHandler: TestFailureHandler) extends Sa
 
   override def withFixture(test: NoArgTest) = {
     if (isRetryable(test))
-      withRetryOnFailure (Span(2, Minutes))(super.withFixture(test))
+      withRetryOnFailure(super.withFixture(test))
     else
       super.withFixture(test)
   }

--- a/test/com/gu/contentapi/sanity/DraftR2ContentShouldAppearInPreviewTest.scala
+++ b/test/com/gu/contentapi/sanity/DraftR2ContentShouldAppearInPreviewTest.scala
@@ -19,7 +19,7 @@ class DraftR2ContentShouldAppearInPreviewTest extends SanityTestBase(testFailure
 
   override def withFixture(test: NoArgTest) = {
     if (isRetryable(test))
-      withRetryOnFailure (Span(1, Minutes))(super.withFixture(test))
+      withRetryOnFailure(super.withFixture(test))
     else
       super.withFixture(test)
   }


### PR DESCRIPTION
Previously these tests had a long wait before attempting to retry. With this change they will retry on failure immediately. I think that makes more sense, especially where people are running the tests locally.

CC @guardian/content-platforms 