### PR TITLE
Revert "Remove the canary collection writing test"

### DIFF
--- a/app/com/gu/contentapi/sanity/CanaryWritingSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryWritingSanityTest.scala
@@ -1,0 +1,54 @@
+package com.gu.contentapi.sanity
+
+import com.gu.contentapi.sanity.support.TestFailureHandler
+import org.scalatest.tagobjects.Retryable
+import org.scalatest.time.{Minutes, Seconds, Span}
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import scala.io.Source
+import org.scalatest.exceptions.TestFailedException
+import play.api.libs.ws.WSAuthScheme
+
+class CanaryWritingSanityTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+
+  val now = new DateTime()
+  val collectionJSON = Source.fromURL(getClass.getResource("/CanaryCollection.json")).getLines().mkString
+  val capiDateStamp = now.toString(ISODateTimeFormat.dateTimeNoMillis().withZoneUTC())
+  val collectionJSONWithNowTimestamp = collectionJSON.replace("2013-10-15T11:42:17Z", capiDateStamp)
+
+  def doesCanaryHaveUpdatedTimestamp = {
+    val httpRequest = requestHost("collections/canary").get()
+    whenReady(httpRequest) { result => result.body.contains(capiDateStamp)}
+  }
+
+  override def withFixture(test: NoArgTest) = {
+    if (isRetryable(test))
+      withRetryOnFailure(super.withFixture(test))
+    else
+      super.withFixture(test)
+  }
+
+
+  "PUTting and GETting a collection" should "show an updated timestamp" taggedAs Retryable in {
+    val putSuccessResponseCode = 202
+    val httpRequest = request(Config.writeHost + "collections/canary")
+      .withAuth(Config.writeUsername, Config.writePassword, WSAuthScheme.BASIC)
+      .withHeaders("Content-Type" -> "application/json")
+      .put(collectionJSONWithNowTimestamp)
+    whenReady(httpRequest) { result =>
+      withClue("Response code was " + result.status + " expected " + putSuccessResponseCode) {
+        result.status should equal(putSuccessResponseCode)
+      }
+      if (result.status == putSuccessResponseCode) {
+        eventually(timeout(Span(60, Seconds))) {
+          withClue("Collection did not show updated date stamp") {
+            doesCanaryHaveUpdatedTimestamp should be(true)
+          }
+        }
+      }
+      else {
+        throw new TestFailedException("Collection did not post successfully", 1)
+      }
+    }
+  }
+}

--- a/app/com/gu/contentapi/sanity/Config.scala
+++ b/app/com/gu/contentapi/sanity/Config.scala
@@ -18,6 +18,8 @@ object Config {
   val apiKey = sanityConfig.getString("api-key")
   val writeHost = sanityConfig.getString("write-host")
   val writePreviewHost = sanityConfig.getString("write-preview-host")
+  val writeUsername = sanityConfig.getString("write-username")
+  val writePassword = sanityConfig.getString("write-password")
   val pagerDutyServiceKey=sanityConfig.getString("pager-duty-service-key")
   val pagerDutyServiceKeyLowPriority=sanityConfig.getString("pager-duty-service-key-low-priority")
   val composerHost = sanityConfig.getString("composer-host")

--- a/app/com/gu/contentapi/sanity/MetaSuites.scala
+++ b/app/com/gu/contentapi/sanity/MetaSuites.scala
@@ -7,6 +7,7 @@ import org.scalatest.Suite
 object MetaSuites {
 
   def prodFrequent(testFailureHandler: TestFailureHandler) = Seq(
+    new CanaryWritingSanityTest(testFailureHandler),
     new CanaryContentSanityTest(testFailureHandler),
     new SearchContainsLargeNumberOfResults(testFailureHandler),
     new PreviewRequiresAuthTest(testFailureHandler),

--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -30,6 +30,15 @@
         "writePreviewHost": {
             "Type": "String"
         },
+        "writeUsername": {
+            "Description": "Porter username",
+            "Type": "String"
+        },
+        "writePassword": {
+            "Description": "Porter password",
+            "Type": "String",
+            "NoEcho": true
+        },
         "pagerDutyServiceKey": {
             "Description": "Pager Duty Service key for High Priority incidents",
             "Type": "String"
@@ -160,6 +169,8 @@
                             { "Fn::Join": [ "", [ "preview-password=\"", { "Ref": "previewPassword" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "api-key=\"", { "Ref": "apiKey" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "write-host=\"", { "Ref": "writeHost" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "write-username=\"", { "Ref": "writeUsername" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "write-password=\"", { "Ref": "writePassword" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "pager-duty-service-key=\"", { "Ref": "pagerDutyServiceKey" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "pager-duty-service-key-low-priority=\"", { "Ref": "pagerDutyServiceKeyLowPriority" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "r2-admin-host=\"", { "Ref": "r2AdminHost" },"\""  ] ] },

--- a/conf/CanaryCollection.json
+++ b/conf/CanaryCollection.json
@@ -1,0 +1,39 @@
+{
+    "type": "features",
+    "title": "Canary in the Coalmine",
+    "groups": [
+        "Main content",
+        "Other articles"
+    ],
+    "curatedContent": [
+        {
+            "id": "world/2013/dec/19/timor-leste-asks-un-court-to-order-australia-return-seized-documents",
+            "metadata": {
+                "trailText": "Asio raids on legal office in Canberra violated sovereignty of Dili",
+                "headline": "Timor-Leste asks UN court to order Australia to return seized documents",
+                "supportingContent": [
+                    {
+                        "id": "music/2013/dec/19/angel-haze-album-released-digitally",
+                        "metadata": {
+                            "headline": "Scarlett Johansson is right: SodaStream does not fit with Oxfam"
+                        }
+                    },
+                    {
+                        "id": "world/2013/dec/04/australia-secret-service-raids-lawyer-and-former-spy"
+                    }
+                ],
+                "imageAdjustment": "hide",
+                "group": 0
+            }
+        },
+        {
+            "id": "environment/video/2013/jul/17/japan-international-court-whaling-video",
+            "metadata": {
+                "group": 1
+            }
+        }
+    ],
+    "backfill": "world",
+    "lastModified": "2013-10-15T11:42:17Z",
+    "modifiedBy": "Gideon Goldberg"
+}

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -14,6 +14,8 @@ content-api-sanity-tests {
     preview-password="capi-preview-password"
     api-key="capi-api-key"
     write-host="https://write-host/"
+    write-username="write-username"
+    write-password="write-password"
     pager-duty-service-key="page-duty-service-key" # Set as 'invalid' if testing locally
     pager-duty-service-key-low-priority="pager-duty-low-priority-service-key" # Set as 'invalid' if testing locally
     r2-admin-host="http://r2-admin-host/"


### PR DESCRIPTION
Reverts guardian/content-api-sanity-tests#50

Oops, it turns out the `/collections` endpoint was needed after all. Resurrect the test for it.