### PR TITLE
Add a CloudWatch alarm to check that tests are actually running

### DIFF
--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,5 +1,5 @@
 import com.gu.contentapi.sanity._
-import com.gu.contentapi.sanity.support.{InfrequentScheduledTestsFailureHandler, FrequentScheduledTestFailureHandler}
+import com.gu.contentapi.sanity.support.{CloudWatchReporter, InfrequentScheduledTestsFailureHandler, FrequentScheduledTestFailureHandler}
 import com.gu.contentapi.sanity.utils.QuartzScheduler
 import org.joda.time.DateTime
 import scala.concurrent.duration._
@@ -9,10 +9,12 @@ import play.api._
 object Global extends GlobalSettings {
 
   override def onStart(app: Application) {
+    val cloudWatchReporter = CloudWatchReporter(app.configuration)
+
     Logger.info("Application has started")
     QuartzScheduler.start()
-    QuartzScheduler schedule("Frequent Tests", runFrequentTests()) every (30 seconds)
-    QuartzScheduler schedule("Infrequent Tests", runInfrequentTests()) at "0 0 9 ? * MON-FRI *"
+    QuartzScheduler schedule("Frequent Tests", runFrequentTests(cloudWatchReporter)) every (30 seconds)
+    QuartzScheduler schedule("Infrequent Tests", runInfrequentTests(cloudWatchReporter)) at "0 0 9 ? * MON-FRI *"
   }
 
   override def onStop(app: Application) {
@@ -20,16 +22,18 @@ object Global extends GlobalSettings {
     QuartzScheduler.stop()
   }
 
-  def runFrequentTests(): Unit = {
+  def runFrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
     println(s"=== Starting frequent tests at ${new DateTime()} ===")
-    val suites = MetaSuites.prodFrequent(testFailureHandler = FrequentScheduledTestFailureHandler)
+    val context = Context(testFailureHandler = FrequentScheduledTestFailureHandler, cloudWatchReporter = cloudWatchReporter)
+    val suites = MetaSuites.prodFrequent(context)
     suites.foreach(_.execute)
     println(s"=== Frequent tests finished at ${new DateTime()} ===")
   }
 
-  def runInfrequentTests(): Unit = {
+  def runInfrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
     println(s"=== Starting infrequent tests at ${new DateTime()} ===")
-    val suites = MetaSuites.prodInfrequent(testFailureHandler = InfrequentScheduledTestsFailureHandler)
+    val context = Context(testFailureHandler = InfrequentScheduledTestsFailureHandler, cloudWatchReporter = cloudWatchReporter)
+    val suites = MetaSuites.prodInfrequent(context)
     suites.foreach(_.execute)
     println(s"=== Infrequent tests finished at ${new DateTime()} ===")
   }

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -28,6 +28,7 @@ object Global extends GlobalSettings {
     val suites = MetaSuites.prodFrequent(context)
     suites.foreach(_.execute)
     println(s"=== Frequent tests finished at ${new DateTime()} ===")
+    cloudWatchReporter.reportTestRunComplete()
   }
 
   def runInfrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
@@ -36,6 +37,7 @@ object Global extends GlobalSettings {
     val suites = MetaSuites.prodInfrequent(context)
     suites.foreach(_.execute)
     println(s"=== Infrequent tests finished at ${new DateTime()} ===")
+    cloudWatchReporter.reportTestRunComplete()
   }
 
 }

--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -11,7 +11,7 @@ import org.joda.time.format.ISODateTimeFormat
  * 1. POSTing to a special endpoint on Porter that creates a new piece of known content and pushes it to Attendant's queue
  * 2. Checking that the content shows up in Concierge with a recent lastModified timestamp
  */
-class CanaryContentSanityTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class CanaryContentSanityTest(context: Context) extends SanityTestBase(context) {
 
   private def retrieveCanaryLastModifiedTimestamp(): Option[DateTime] = {
     val httpRequest = requestHost("/canary?show-fields=lastModified").get()

--- a/app/com/gu/contentapi/sanity/ContentApiSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/ContentApiSanityTest.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 
-class ContentApiSanityTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class ContentApiSanityTest(context: Context) extends SanityTestBase(context) {
 
   "Content api" should "serve gzipped" in {
     // GZip Compression is enabled in application.conf

--- a/app/com/gu/contentapi/sanity/Context.scala
+++ b/app/com/gu/contentapi/sanity/Context.scala
@@ -1,0 +1,19 @@
+package com.gu.contentapi.sanity
+
+import com.gu.contentapi.sanity.support.{DoNothingCloudWatchReporter, DoNothingTestFailureHandler, CloudWatchReporter, TestFailureHandler}
+
+case class Context(testFailureHandler: TestFailureHandler,
+                   cloudWatchReporter: CloudWatchReporter)
+
+object Context {
+
+  /**
+   * The context to be used when running `sbt test`.
+   * Does not send any PagerDuty alerts or report any metrics to CloudWatch.
+   */
+  val Testing = Context(testFailureHandler = DoNothingTestFailureHandler,
+                        cloudWatchReporter = DoNothingCloudWatchReporter)
+
+}
+
+

--- a/app/com/gu/contentapi/sanity/CriticalTagsTest.scala
+++ b/app/com/gu/contentapi/sanity/CriticalTagsTest.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 
-class CriticalTagsTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class CriticalTagsTest(context: Context) extends SanityTestBase(context) {
 
   "Tags critical for publication (including Kindle)" should "exist" in {
     val criticalTags = Seq(

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -6,7 +6,7 @@ import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
 
 @ProdOnly
-class CrosswordsIndexingTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class CrosswordsIndexingTest(context: Context) extends SanityTestBase(context) {
 
   "A new Crossword" should "be indexed every day" taggedAs LowPriorityTest in {
     val now = DateTime.now

--- a/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.sanity.tags.ProdOnly
 import play.api.libs.json.Json
 
 @ProdOnly
-class EditorsPicksContainsItemsTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class EditorsPicksContainsItemsTest(context: Context) extends SanityTestBase(context) {
 
   "Editors picks for /uk" should "not be empty" in {
     val httpRequest = requestHost("/uk?show-editors-picks=true").get()

--- a/app/com/gu/contentapi/sanity/GetNonExistentContentShould404.scala
+++ b/app/com/gu/contentapi/sanity/GetNonExistentContentShould404.scala
@@ -2,7 +2,7 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 
-class GetNonExistentContentShould404(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class GetNonExistentContentShould404(context: Context) extends SanityTestBase(context) {
 
     "GETting non existent content" should "404" in {
       val httpRequest = requestHost("foo/should-not-exist").get()

--- a/app/com/gu/contentapi/sanity/JREVersionTest.scala
+++ b/app/com/gu/contentapi/sanity/JREVersionTest.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.sanity.tags.{ProdOnly, LowPriorityTest}
 import org.scalatest.time.{Span, Seconds}
 
 @ProdOnly
-class JREVersionTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class JREVersionTest(context: Context) extends SanityTestBase(context) {
 
   {
     "The Content API" should "be using the latest JRE" taggedAs LowPriorityTest in {

--- a/app/com/gu/contentapi/sanity/MetaSuites.scala
+++ b/app/com/gu/contentapi/sanity/MetaSuites.scala
@@ -1,36 +1,35 @@
 package com.gu.contentapi.sanity
 
-import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.ProdOnly
 import org.scalatest.Suite
 
 object MetaSuites {
 
-  def prodFrequent(testFailureHandler: TestFailureHandler) = Seq(
-    new CanaryContentSanityTest(testFailureHandler),
-    new SearchContainsLargeNumberOfResults(testFailureHandler),
-    new PreviewRequiresAuthTest(testFailureHandler),
-    new ContentApiSanityTest(testFailureHandler),
-    new GetNonExistentContentShould404(testFailureHandler),
-    new PreviewContentSetNotInLiveTest(testFailureHandler),
-    new ValidateArticleSchema(testFailureHandler),
-    new NewestItemFieldsTest(testFailureHandler),
-    new MostViewedContainsItemsTest(testFailureHandler),
-    new EditorsPicksContainsItemsTest(testFailureHandler),
-    new CriticalTagsTest(testFailureHandler),
-    new TagSearchContainsLargeNumberOfResults(testFailureHandler),
-    new ShowBlocksTest(testFailureHandler)
+  def prodFrequent(context: Context) = Seq(
+    new CanaryContentSanityTest(context),
+    new SearchContainsLargeNumberOfResults(context),
+    new PreviewRequiresAuthTest(context),
+    new ContentApiSanityTest(context),
+    new GetNonExistentContentShould404(context),
+    new PreviewContentSetNotInLiveTest(context),
+    new ValidateArticleSchema(context),
+    new NewestItemFieldsTest(context),
+    new MostViewedContainsItemsTest(context),
+    new EditorsPicksContainsItemsTest(context),
+    new CriticalTagsTest(context),
+    new TagSearchContainsLargeNumberOfResults(context),
+    new ShowBlocksTest(context)
   )
 
-  def prodInfrequent(testFailureHandler: TestFailureHandler) = Seq(
-    new JREVersionTest(testFailureHandler),
-    new SSLExpiryTest(testFailureHandler),
-    new CrosswordsIndexingTest(testFailureHandler)
+  def prodInfrequent(context: Context) = Seq(
+    new JREVersionTest(context),
+    new SSLExpiryTest(context),
+    new CrosswordsIndexingTest(context)
   )
 
   /** All suites that can be run against either PROD or CODE */
-  def suitableForBothProdAndCode(testFailureHandler: TestFailureHandler) =
-    (prodFrequent(testFailureHandler) ++ prodInfrequent(testFailureHandler))
+  def suitableForBothProdAndCode(context: Context) =
+    (prodFrequent(context) ++ prodInfrequent(context))
       .filter(isNotTaggedWithProdOnly)
 
   private def isNotTaggedWithProdOnly(s: Suite): Boolean = {

--- a/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
@@ -5,7 +5,7 @@ import com.gu.contentapi.sanity.tags.ProdOnly
 import play.api.libs.json.Json
 
 @ProdOnly
-class MostViewedContainsItemsTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class MostViewedContainsItemsTest(context: Context) extends SanityTestBase(context) {
 
   "Most Viewed" should "contain more than 10 items" in {
     val httpRequest = requestHost("/uk?show-most-viewed=true").get()

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.{JsValue, Json}
 
-class NewestItemFieldsTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class NewestItemFieldsTest(context: Context) extends SanityTestBase(context) {
 
   "The newest items" should "include mandatory fields" in {
     val mandatoryItemFields = Seq[String](

--- a/app/com/gu/contentapi/sanity/PreviewContentSetNotInLiveTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewContentSetNotInLiveTest.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.Json
 
-class PreviewContentSetNotInLiveTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class PreviewContentSetNotInLiveTest(context: Context) extends SanityTestBase(context) {
 
   "GETting the preview content set JSON" should "show no results on live" in {
     val httpRequest = requestHost("search?content-set=preview").get()

--- a/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import org.scalatest.time.{Seconds, Span}
 
-class PreviewRequiresAuthTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class PreviewRequiresAuthTest(context: Context) extends SanityTestBase(context) {
 
   "GETting preview content" should "require authentication" in {
     //Sometimes this throws a java.io.IOException, with message: Remotely Closed, so using Eventually to retry

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -12,7 +12,7 @@ import sun.security.x509.X509CertImpl
 import scala.util.Try
 
 @ProdOnly
-class SSLExpiryTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class SSLExpiryTest(context: Context) extends SanityTestBase(context) {
 
   "SSL Certificates" should "be more than 30 days from expiry" taggedAs LowPriorityTest in {
     val hosts = Seq(

--- a/app/com/gu/contentapi/sanity/SanityTestBase.scala
+++ b/app/com/gu/contentapi/sanity/SanityTestBase.scala
@@ -1,13 +1,19 @@
 package com.gu.contentapi.sanity
 
-import com.gu.contentapi.sanity.support.{TestFailureHandler, XmlFileSupport, TestFailureHandlingSupport, HttpRequestSupport}
+import com.gu.contentapi.sanity.support._
 import org.scalatest.{Matchers, OptionValues, Retries, FlatSpec}
 import org.scalatest.concurrent.{ScalaFutures, IntegrationPatience, Eventually}
 
-abstract class SanityTestBase(val testFailureHandler: TestFailureHandler)
+abstract class SanityTestBase(context: Context)
   extends FlatSpec with Matchers with OptionValues
   with Eventually with Retries with ScalaFutures with IntegrationPatience
-  with HttpRequestSupport with TestFailureHandlingSupport with XmlFileSupport
+  with TestFailureHandlingSupport with CloudWatchReportingSupport
+  with HttpRequestSupport with XmlFileSupport {
+
+  val testFailureHandler = context.testFailureHandler
+  val cloudWatchReporter = context.cloudWatchReporter
+
+}
 
 
 

--- a/app/com/gu/contentapi/sanity/SearchContainsLargeNumberOfResults.scala
+++ b/app/com/gu/contentapi/sanity/SearchContainsLargeNumberOfResults.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.Json
 
-class SearchContainsLargeNumberOfResults(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class SearchContainsLargeNumberOfResults(context: Context) extends SanityTestBase(context) {
 
   "The Content API" should "return a large total of results on the /search endpoint" in {
     val httpRequest = requestHost("search").get()

--- a/app/com/gu/contentapi/sanity/ShowBlocksTest.scala
+++ b/app/com/gu/contentapi/sanity/ShowBlocksTest.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.{JsArray, JsValue, Json}
 
-class ShowBlocksTest(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class ShowBlocksTest(context: Context) extends SanityTestBase(context) {
 
   "The newest Flex items in the search results" should "include blocks if show-blocks=all" in {
 

--- a/app/com/gu/contentapi/sanity/TagSearchContainsLargeNumberOfResults.scala
+++ b/app/com/gu/contentapi/sanity/TagSearchContainsLargeNumberOfResults.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.Json
 
-class TagSearchContainsLargeNumberOfResults(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class TagSearchContainsLargeNumberOfResults(context: Context) extends SanityTestBase(context) {
 
   "The Content API" should "return a large total of tags on the /tags endpoint" in {
     val httpRequest = requestHost("tags").get()

--- a/app/com/gu/contentapi/sanity/ValidateArticleSchema.scala
+++ b/app/com/gu/contentapi/sanity/ValidateArticleSchema.scala
@@ -3,7 +3,7 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.Json
 
-class ValidateArticleSchema(testFailureHandler: TestFailureHandler) extends SanityTestBase(testFailureHandler) {
+class ValidateArticleSchema(context: Context) extends SanityTestBase(context) {
 
   "The Content API" should "return correct article schema" in {
     val httpRequest = requestHost("/lifeandstyle/lostinshowbiz/2014/sep/18/charlotte-crosby-blueprint-for-civilisation-geordie-shore-celebrity-big-brother?show-fields=all&show-elements=all").get()

--- a/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
@@ -1,0 +1,32 @@
+package com.gu.contentapi.sanity.support
+
+import play.api.Configuration
+
+trait CloudWatchReportingSupport {
+
+  def cloudWatchReporter: CloudWatchReporter
+
+}
+
+trait CloudWatchReporter {
+
+  def reportSuccessfulTest(): Unit
+  def reportFailedTest(): Unit
+  def reportTestRunComplete(): Unit
+
+}
+
+object CloudWatchReporter {
+
+  def apply(config: Configuration): CloudWatchReporter = {
+    // TODO
+    DoNothingCloudWatchReporter
+  }
+
+}
+
+object DoNothingCloudWatchReporter extends CloudWatchReporter {
+  override def reportSuccessfulTest(): Unit = {}
+  override def reportFailedTest(): Unit = {}
+  override def reportTestRunComplete(): Unit = {}
+}

--- a/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
@@ -1,6 +1,10 @@
 package com.gu.contentapi.sanity.support
 
-import play.api.Configuration
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.regions.{ServiceAbbreviations, Regions, Region}
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
+import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, Dimension}
+import play.api.{Logger, Configuration}
 
 trait CloudWatchReportingSupport {
 
@@ -19,9 +23,67 @@ trait CloudWatchReporter {
 object CloudWatchReporter {
 
   def apply(config: Configuration): CloudWatchReporter = {
-    // TODO
-    DoNothingCloudWatchReporter
+    def cfg(key: String) = config.getString(s"content-api-sanity-tests.cloudwatch-$key")
+    val reporter = for {
+      namespace <- cfg("namespace")
+      stack <- cfg("stack")
+      testRunsMetric <- cfg("test-runs-metric")
+      successfulTestsMetric <- cfg("successful-tests-metric")
+      failedTestsMetric <- cfg("failed-tests-metric")
+    } yield {
+      Logger.info(s"Will report metrics to CloudWatch. namespace=$namespace, stack=$stack, metrics=($testRunsMetric, $successfulTestsMetric, $failedTestsMetric)")
+      new RealCloudWatchReporter(namespace, stack, testRunsMetric, successfulTestsMetric, failedTestsMetric)
+    }
+
+    reporter getOrElse {
+      Logger.info("Will not report any metrics to CloudWatch")
+      DoNothingCloudWatchReporter
+    }
   }
+
+}
+
+class RealCloudWatchReporter(namespace: String,
+                              stack: String,
+                              testRunsMetric: String,
+                              successfulTestsMetric: String,
+                              failedTestsMetric: String) extends CloudWatchReporter {
+
+  private val region = Region.getRegion(Regions.EU_WEST_1)
+
+  lazy val stackDimension = new Dimension().withName("Stack").withValue(stack)
+
+  lazy val cloudwatch = {
+    val client = new AmazonCloudWatchAsyncClient()
+    client.setEndpoint(region.getServiceEndpoint(ServiceAbbreviations.CloudWatch))
+    client
+  }
+
+  object LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, Void] {
+    def onError(exception: Exception) {
+      Logger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
+    }
+    def onSuccess(request: PutMetricDataRequest, result: Void) {
+      Logger.trace("CloudWatch PutMetricDataRequest - success")
+    }
+  }
+
+  private def put(metricName: String, value: Double): Unit = {
+    val metric = new MetricDatum()
+      .withValue(value)
+      .withMetricName(metricName)
+      .withDimensions(stackDimension)
+
+    val request = new PutMetricDataRequest().withNamespace(namespace).withMetricData(metric)
+
+    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
+  }
+
+  override def reportSuccessfulTest(): Unit = put(successfulTestsMetric, 1)
+
+  override def reportFailedTest(): Unit = put(failedTestsMetric, 1)
+
+  override def reportTestRunComplete(): Unit = put(testRunsMetric, 1)
 
 }
 

--- a/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
@@ -4,11 +4,22 @@ import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.regions.{ServiceAbbreviations, Regions, Region}
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
 import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, Dimension}
+import org.scalatest.{Succeeded, Failed, Outcome, Suite}
 import play.api.{Logger, Configuration}
 
-trait CloudWatchReportingSupport {
+trait CloudWatchReportingSupport extends Suite {
 
   def cloudWatchReporter: CloudWatchReporter
+
+  override protected def withFixture(test: NoArgTest): Outcome = {
+    val outcome = super.withFixture(test)
+    outcome match {
+      case Failed(e) => cloudWatchReporter.reportFailedTest()
+      case Succeeded => cloudWatchReporter.reportSuccessfulTest()
+      case _ => // do nothing
+    }
+    outcome
+  }
 
 }
 

--- a/app/com/gu/contentapi/sanity/support/TestFailureHandlingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/TestFailureHandlingSupport.scala
@@ -163,6 +163,6 @@ object InfrequentScheduledTestsFailureHandler extends PagerDutyAlertingTestFailu
 
 }
 
-object DoNothing extends TestFailureHandler {
+object DoNothingTestFailureHandler extends TestFailureHandler {
   override def handleTestFailure(testName: String, exception: Throwable, tags: Set[String]): Unit = {}
 }

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,8 @@ libraryDependencies ++= Seq(
   "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
   "com.github.cb372" %% "play-configurable-ningwsplugin" % "0.2",
-  "org.scalatestplus" %% "play" % "1.1.1"
+  "org.scalatestplus" %% "play" % "1.1.1",
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.2"
 )
 
 parallelExecution in ThisBuild := false

--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -16,6 +16,10 @@
             "Description": "Subnets to run load balancer within",
             "Type": "List<AWS::EC2::Subnet::Id>"
         },
+        "AlarmTopic": {
+            "Description": "A SNS topic ARN for Cloudwatch alerts",
+            "Type": "String"
+        },
         "host": {
             "Description": "Content API host",
             "Type": "String"
@@ -71,6 +75,22 @@
             "Description": "R2 Admin CODE password",
             "Type": "String",
             "NoEcho": true
+        },
+        "cloudwatchNamespace": {
+            "Type": "String",
+            "Default": "content-api-sanity-tests"
+        },
+        "cloudwatchTestRunsMetric": {
+            "Type": "String",
+            "Default": "TestRuns"
+        },
+        "cloudwatchSuccessfulTestsMetric": {
+            "Type": "String",
+            "Default": "SuccessfulTests"
+        },
+        "cloudwatchFailedTestsMetric": {
+            "Type": "String",
+            "Default": "content-api-sanity-tests"
         }
     },
 
@@ -226,6 +246,10 @@
                             { "Fn::Join": [ "", [ "r2-admin-username=\"", { "Ref": "r2AdminUsername" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "r2-admin-password=\"", { "Ref": "r2AdminPassword" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "composer-host=\"", { "Ref": "composerHost" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "cloudwatch-namespace=\"", { "Ref": "cloudwatchNamespace" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "cloudwatch-test-runs-metric=\"", { "Ref": "cloudwatchTestRunsMetric" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "cloudwatch-successful-tests-metric=\"", { "Ref": "cloudwatchSuccessfulTestsMetric" },"\""  ] ] },
+                            { "Fn::Join": [ "", [ "cloudwatch-failed-tests-metric=\"", { "Ref": "cloudwatchFailedTestsMetric" },"\""  ] ] },
                             "}",
                             "ws.compressionEnabled=true",
                             "ws.ning.maximumConnectionLifeTime = 60000",
@@ -285,6 +309,21 @@
                         "CidrIp": "77.91.248.0/21"
                     }
                 ]
+            }
+        },
+        "NotEnoughSuccessfulTestsAlarm": {
+            "Type": "AWS::CloudWatch::Alarm",
+            "Properties": {
+                "AlarmName": { "Fn::Join": ["-", [ "content-api-sanity-tests", { "Ref": "Stage" }, "alarm", "not-enough-successful-tests" ] ] },
+                "AlarmDescription": "Fewer than 100 tests in 5 minutes (we expect to run at least 14 tests every 30 seconds)",
+                "Namespace": { "Ref": "cloudwatch-namespace" },
+                "MetricName": "SuccessfulTests",
+                "Statistic": "Sum",
+                "ComparisonOperator": "LessThanThreshold",
+                "Threshold": "100",
+                "Period": "300",
+                "EvaluationPeriods": "5",
+                "AlarmActions": { "Ref": "AlarmTopic" }
             }
         }
     },

--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -75,6 +75,56 @@
     },
 
     "Resources": {
+        "Role": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": { "Service": ["ec2.amazonaws.com" ] },
+                        "Action": [ "sts:AssumeRole" ]
+                    }]
+                },
+                "Path": "/"
+            }
+        },
+        "RolePolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "root",
+                "PolicyDocument": {
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": ["cloudformation:DescribeStackResource", "s3:*"],
+                        "Resource": "*"
+                    }]
+                },
+                "Roles": [{ "Ref": "Role" }]
+            }
+        },
+        "CloudwatchPolicy": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "cloudwatch-put",
+                "PolicyDocument": {
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Action": [ "cloudwatch:PutMetricData" ],
+                            "Resource": "*"
+                        }
+                    ]
+                },
+                "Roles": [{"Ref": "Role" }]
+            }
+        },
+        "InstanceProfile": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Path": "/",
+                "Roles": [{ "Ref": "Role" }]
+            }
+        },
         "LoadBalancer": {
             "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
             "Properties": {
@@ -137,6 +187,7 @@
                 "AssociatePublicIpAddress": true,
                 "SecurityGroups": [ { "Ref": "SecurityGroup" } ],
                 "InstanceType": "t2.micro",
+                "IamInstanceProfile": { "Ref": "InstanceProfile" },
                 "UserData": {
                     "Fn::Base64": {
                         "Fn::Join": [ "\n", [

--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -316,7 +316,7 @@
             "Properties": {
                 "AlarmName": { "Fn::Join": ["-", [ "content-api-sanity-tests", { "Ref": "Stage" }, "alarm", "not-enough-successful-tests" ] ] },
                 "AlarmDescription": "Fewer than 100 tests in 5 minutes (we expect to run at least 14 tests every 30 seconds)",
-                "Namespace": { "Ref": "cloudwatch-namespace" },
+                "Namespace": { "Ref": "cloudwatchNamespace" },
                 "MetricName": "SuccessfulTests",
                 "Statistic": "Sum",
                 "ComparisonOperator": "LessThanThreshold",

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -23,9 +23,9 @@ content-api-sanity-tests {
 
     # PROD only. In other environments, these keys can be omitted.
     # If any key is omitted, nothing will be reported to CloudWatch.
-    test-runs-cloudwatch-namespace="content-api-sanity-tests"
-    test-runs-cloudwatch-stack="content-api-sanity-tests"
-    test-runs-cloudwatch-testruns-metric="TestRuns"
-    test-runs-cloudwatch-successful-tests-metric="SuccessfulTests"
-    test-runs-cloudwatch-failed-tests-metric="FailedTests"
+    cloudwatch-namespace="content-api-sanity-tests"
+    cloudwatch-stack="content-api-sanity-tests"
+    cloudwatch-test-runs-metric="TestRuns"
+    cloudwatch-successful-tests-metric="SuccessfulTests"
+    cloudwatch-failed-tests-metric="FailedTests"
 }

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -24,7 +24,6 @@ content-api-sanity-tests {
     # PROD only. In other environments, these keys can be omitted.
     # If any key is omitted, nothing will be reported to CloudWatch.
     cloudwatch-namespace="content-api-sanity-tests"
-    cloudwatch-stack="content-api-sanity-tests"
     cloudwatch-test-runs-metric="TestRuns"
     cloudwatch-successful-tests-metric="SuccessfulTests"
     cloudwatch-failed-tests-metric="FailedTests"

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -20,4 +20,12 @@ content-api-sanity-tests {
     r2-admin-username="r2-admin-username"
     r2-admin-password="r2-admin-password"
     composer-host="http://composer-host/"
+
+    # PROD only. In other environments, these keys can be omitted.
+    # If any key is omitted, nothing will be reported to CloudWatch.
+    test-runs-cloudwatch-namespace="content-api-sanity-tests"
+    test-runs-cloudwatch-stack="content-api-sanity-tests"
+    test-runs-cloudwatch-testruns-metric="TestRuns"
+    test-runs-cloudwatch-successful-tests-metric="SuccessfulTests"
+    test-runs-cloudwatch-failed-tests-metric="FailedTests"
 }

--- a/test/com/gu/contentapi/sanity/CODESuite.scala
+++ b/test/com/gu/contentapi/sanity/CODESuite.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi.sanity
 
-import com.gu.contentapi.sanity.support.{FakeAppSupport, DoNothing}
+import com.gu.contentapi.sanity.support.{FakeAppSupport, DoNothingTestFailureHandler}
 import org.scalatest.Suites
 
 /**
@@ -8,7 +8,7 @@ import org.scalatest.Suites
  */
 class CODESuite extends Suites(
   CODESuite.CodeOnlySuites ++
-  MetaSuites.suitableForBothProdAndCode(testFailureHandler = DoNothing): _*) with FakeAppSupport
+  MetaSuites.suitableForBothProdAndCode(context = Context.Testing): _*) with FakeAppSupport
 
 object CODESuite {
 

--- a/test/com/gu/contentapi/sanity/DraftR2ContentShouldAppearInPreviewTest.scala
+++ b/test/com/gu/contentapi/sanity/DraftR2ContentShouldAppearInPreviewTest.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi.sanity
 
-import com.gu.contentapi.sanity.support.DoNothing
+import com.gu.contentapi.sanity.support.DoNothingTestFailureHandler
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.scalatest.DoNotDiscover
@@ -15,7 +15,7 @@ import scala.io.Source
  * It's in the `/test` folder so that you can't accidentally run it in the scheduler.
  */
 @DoNotDiscover
-class DraftR2ContentShouldAppearInPreviewTest extends SanityTestBase(testFailureHandler = DoNothing) with WebBrowser {
+class DraftR2ContentShouldAppearInPreviewTest extends SanityTestBase(context = Context.Testing) with WebBrowser {
 
   override def withFixture(test: NoArgTest) = {
     if (isRetryable(test))

--- a/test/com/gu/contentapi/sanity/ReadComposerDraftInPreviewTest.scala
+++ b/test/com/gu/contentapi/sanity/ReadComposerDraftInPreviewTest.scala
@@ -1,6 +1,6 @@
 package com.gu.contentapi.sanity
 
-import com.gu.contentapi.sanity.support.DoNothing
+import com.gu.contentapi.sanity.support.DoNothingTestFailureHandler
 import org.scalatest.DoNotDiscover
 import org.scalatest.time.{Seconds, Span}
 
@@ -13,7 +13,7 @@ import scala.util.Random
  * It's in the `/test` folder so that you can't accidentally run it in the scheduler.
  */
 @DoNotDiscover
-class ReadComposerDraftInPreviewTest extends SanityTestBase(testFailureHandler = DoNothing) {
+class ReadComposerDraftInPreviewTest extends SanityTestBase(context = Context.Testing) {
 
   val modifiedHeadline = "Content API Sanity Test " + java.util.UUID.randomUUID.toString
   val uniquePageId = Random.nextInt().toString


### PR DESCRIPTION
* Publish metrics (only in PROD) on the number of successful tests, failed tests, and test runs (i.e. the whole suite of tests being run) to CloudWatch
* Add an alarm to alert us if the number of successful tests drops below a threshold

Note that this is in addition to, not a replacement for, the existing PagerDuty alerts that are triggered when tests fail. We had a problem recently where the test suite was crashing before even trying to run the tests, so the tests did not fail, thus we didn't get any PagerDuty alerts. The system was just crashing every 30 seconds and we had no way of knowing.