### PR TITLE
Revert "deactivate test"

### DIFF
--- a/app/com/gu/contentapi/sanity/ContentSetFeaturesTest.scala
+++ b/app/com/gu/contentapi/sanity/ContentSetFeaturesTest.scala
@@ -18,7 +18,7 @@ class ContentSetFeaturesTest(context: Context) extends SanityTestBase(context) {
     }
   }
 
-  /*"GETting the print-sent content set JSON" should "return a newspaper-book-section tag for each result" in {
+  "GETting the print-sent content set JSON" should "return a newspaper-book-section tag for each result" in {
     val httpRequest = requestHost("search?content-set=print-sent&show-tags=newspaper-book-section").get()
 
     whenReady(httpRequest) { result =>
@@ -34,6 +34,6 @@ class ContentSetFeaturesTest(context: Context) extends SanityTestBase(context) {
         }
       }
     }
-  }*/
+  }
 
 }


### PR DESCRIPTION
Reverts guardian/content-api-sanity-tests#62
Shoud be fixed by https://github.com/guardian/api-indexer/pull/143
