### PR TITLE
Disable canary test

### DIFF
--- a/app/com/gu/contentapi/sanity/MetaSuites.scala
+++ b/app/com/gu/contentapi/sanity/MetaSuites.scala
@@ -6,7 +6,7 @@ import org.scalatest.Suite
 object MetaSuites {
 
   def prodFrequent(context: Context) = Seq(
-    new CanaryContentSanityTest(context),
+    /*new CanaryContentSanityTest(context),*/
     new SearchContainsLargeNumberOfResults(context),
     new PreviewRequiresAuthTest(context),
     new ContentApiSanityTest(context),


### PR DESCRIPTION
Until push to porter return useful response when switch is not activated