### PR TITLE
Disable JRE version test for now

### DIFF
--- a/app/com/gu/contentapi/sanity/MetaSuites.scala
+++ b/app/com/gu/contentapi/sanity/MetaSuites.scala
@@ -22,7 +22,7 @@ object MetaSuites {
   )
 
   def prodInfrequent(context: Context) = Seq(
-    new JREVersionTest(context),
+    //new JREVersionTest(context), disabled for now because it spams us every day
     new SSLExpiryTest(context),
     new CrosswordsIndexingTest(context)
   )


### PR DESCRIPTION
Because it spams us every morning.

The Ubuntu package maintainers don't seem to have any plans to update
the openjdk-8-jre-headless package on vivid.