### PR TITLE
Assume not 504 for canary test

### DIFF
--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -33,7 +33,9 @@ class CanaryContentSanityTest(context: Context) extends SanityTestBase(context) 
     val httpRequest = request(Config.writeHost + "canary/content")
       .withHeaders("Content-Type" -> "application/json")
       .post("")
+    
     whenReady(httpRequest) { result =>
+      assumeNot(504)(result)
       withClue("Response code was " + result.status + " expected " + postSuccessResponseCode) {
         result.status should equal(postSuccessResponseCode)
       }

--- a/app/com/gu/contentapi/sanity/CriticalTagsTest.scala
+++ b/app/com/gu/contentapi/sanity/CriticalTagsTest.scala
@@ -22,7 +22,7 @@ class CriticalTagsTest(context: Context) extends SanityTestBase(context) {
     for (criticalTag <- criticalTags) {
       val httpRequest = requestHost(criticalTag).get()
       whenReady(httpRequest) { result =>
-        assumeNot5xxResponse(result)
+        assumeNot(503, 504)(result)
         withClue("Failed attempting to GET " + Config.host + criticalTag) {
           result.status should equal(200)
         }

--- a/app/com/gu/contentapi/sanity/GetNonExistentContentShould404.scala
+++ b/app/com/gu/contentapi/sanity/GetNonExistentContentShould404.scala
@@ -7,7 +7,7 @@ class GetNonExistentContentShould404(context: Context) extends SanityTestBase(co
     "GETting non existent content" should "404" in {
       val httpRequest = requestHost("foo/should-not-exist").get()
       whenReady(httpRequest) { result =>
-        assumeNot5xxResponse(result)
+        assumeNot(503, 504)(result)
         result.status should be(404)
       }
     }

--- a/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
@@ -10,7 +10,7 @@ class PreviewRequiresAuthTest(context: Context) extends SanityTestBase(context) 
     eventually(timeout(Span(15, Seconds)),interval(Span(3, Seconds))) {
       val httpRequest = request(Config.previewHost).get()
       whenReady(httpRequest) { result =>
-        assumeNot5xxResponse(result)
+        assumeNot(503, 504)(result)
         result.status should be(401)
 
       }

--- a/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
@@ -32,9 +32,15 @@ trait HttpRequestSupport extends ScalaFutures with Matchers with Assertions {
     }
   }
 
-  def assumeNot5xxResponse(response: WSResponse): Unit = {
-    assume(response.status !=503,"Service is down")
-    assume(response.status !=504,"ELB timeout")
+  import HttpRequestSupport._
+
+  def assumeNot(statuses:Int*)(response: WSResponse): Unit = {
+    statuses.foreach(s => assume(response.status != s, statusMsg.get(s).getOrElse("")))
   }
 
+}
+
+
+object HttpRequestSupport {
+  val statusMsg = Map(503 -> "Service is currently not available", 504 -> "ELB timeout")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
 * Do not fail for canary test if ELB is replying 504
 * Refactor `assumeNot5xxResponse` to `assumeNot`