### PR TITLE
Add a hack to work around a ScalaTest bug

### DIFF
--- a/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
@@ -1,6 +1,5 @@
 package com.gu.contentapi.sanity
 
-import com.gu.contentapi.sanity.support.TestFailureHandler
 import org.scalatest.time.{Seconds, Span}
 
 class PreviewRequiresAuthTest(context: Context) extends SanityTestBase(context) {
@@ -10,7 +9,7 @@ class PreviewRequiresAuthTest(context: Context) extends SanityTestBase(context) 
     eventually(timeout(Span(21, Seconds)),interval(Span(3, Seconds))) {
       val httpRequest = request(Config.previewHost).get()
       whenReady(httpRequest) { result =>
-        assumeNot(503, 504)(result)
+        assumeNotInsideEventually(503, 504)(result)
         result.status should be(401)
 
       }

--- a/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
@@ -1,6 +1,7 @@
 package com.gu.contentapi.sanity.support
 
 import com.gu.contentapi.sanity.Config
+import org.scalatest.exceptions.TestPendingException
 import org.scalatest.{Assertions, Matchers}
 import org.scalatest.concurrent.ScalaFutures
 import play.api.libs.ws.{WSResponse, WSAuthScheme, WS, WSRequestHolder}
@@ -35,7 +36,12 @@ trait HttpRequestSupport extends ScalaFutures with Matchers with Assertions {
   import HttpRequestSupport._
 
   def assumeNot(statuses:Int*)(response: WSResponse): Unit = {
-    statuses.foreach(s => assume(response.status != s, statusMsg.get(s).getOrElse("")))
+    statuses.foreach(s => assume(response.status != s, statusMsg.getOrElse(s, "")))
+  }
+
+  def assumeNotInsideEventually(statuses:Int*)(response: WSResponse): Unit = {
+    // workaround until https://github.com/scalatest/scalatest/pull/807 is merged
+    statuses.foreach(s => if (response.status != s) throw new TestPendingException)
   }
 
 }


### PR DESCRIPTION
We need to do some hackery when we want to use `assume` inside an `eventually` construct.

See https://github.com/scalatest/scalatest/pull/807