### PR TITLE
Update dependencies

### DIFF
--- a/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
@@ -4,12 +4,13 @@ import com.gu.contentapi.sanity.Config
 import org.scalatest.exceptions.TestPendingException
 import org.scalatest.{Assertions, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import play.api.libs.ws.{WSResponse, WSAuthScheme, WS, WSRequestHolder}
+import play.api.libs.ws.{WSResponse, WSAuthScheme, WS, WSRequest}
 import play.api.Play.current
+import scala.concurrent.duration._
 
 trait HttpRequestSupport extends ScalaFutures with Matchers with Assertions {
 
-  def request(uri: String): WSRequestHolder = WS.url(uri).withRequestTimeout(10000)
+  def request(uri: String): WSRequest = WS.url(uri).withRequestTimeout(10000.millis)
 
   def requestHost(path: String) =
     // make sure query string is included

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,24 @@
-import play.PlayScala
-
 name := "sanity-tests"
 
 version := "1.0"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-feature")
+
+routesGenerator := StaticRoutesGenerator
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(
   "org.quartz-scheduler" % "quartz" % "2.1.6",
-  "org.scalatest" %% "scalatest" % "2.1.4",
+  "org.scalatest" %% "scalatest" % "2.2.6",
   "org.seleniumhq.selenium" % "selenium-java" % "2.41.0",
   "joda-time" % "joda-time" % "2.7",
   ws,
   "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
-  "com.github.cb372" %% "play-configurable-ningwsplugin" % "0.2",
-  "org.scalatestplus" %% "play" % "1.1.1",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.2"
 )
 

--- a/cloud-formation/cfn.json
+++ b/cloud-formation/cfn.json
@@ -226,8 +226,8 @@
                             { "Fn::Join": [ "", [ "cloudwatch-successful-tests-metric=\"", { "Ref": "cloudwatchSuccessfulTestsMetric" },"\""  ] ] },
                             { "Fn::Join": [ "", [ "cloudwatch-failed-tests-metric=\"", { "Ref": "cloudwatchFailedTestsMetric" },"\""  ] ] },
                             "}",
-                            "ws.compressionEnabled=true",
-                            "ws.ning.maximumConnectionLifeTime = 60000",
+                            "play.ws.compressionEnabled=true",
+                            "play.ws.ahc.maxConnectionLifetime = 1 minute",
                             "EOF",
                             "systemctl start sanity-tests"
                         ] ]

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -1,7 +1,7 @@
-# WS configuration, see http://www.playframework.com/documentation/2.3.x/ScalaWS
-ws.compressionEnabled=true
+# WS configuration, see http://www.playframework.com/documentation/2.5.x/ScalaWS
+play.ws.compressionEnabled=true
 # Don't pool WS client connections for more than a minute
-ws.ning.maximumConnectionLifeTime = 60000
+play.ws.ahc.maxConnectionLifetime = 1 minute
 
 # these are our own config values defined by the app
 # rename this to application.conf with real values

--- a/conf/play.plugins
+++ b/conf/play.plugins
@@ -1,2 +1,0 @@
-# This priority has to be < 700, so that we are used in preference to the default NingWSPlugin
-100:play.plugins.ConfigurableNingWSPlugin

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.10")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")


### PR DESCRIPTION
 * play to `2.5.4`
 * scala to `2.11.8`
 * sbt to `0.13.11`

I have intentionally left 5 deprecation warnings, as I think they are not worth fixing now:

``` 
method url in object WS is deprecated: Inject WSClient into your component
object WS in package ws is deprecated: Inject WSClient into your component
method current in object Play is deprecated: This is a static reference to application, use DI instead
trait GlobalSettings in package api is deprecated: Use dependency injection
class FakeApplication in package test is deprecated: Use GuiceApplicationBuilder instead.
```

