### PR TITLE
Amend failing editors picks test.

### DIFF
--- a/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
@@ -12,9 +12,7 @@ class EditorsPicksContainsItemsTest(context: Context) extends SanityTestBase(con
     whenReady(httpRequest) { result =>
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
-      val editorsPicksJson = (json \ "response" \ "editorsPicks")
-      val editorsPicksList = editorsPicksJson.as[List[Map[String, String]]]
-      editorsPicksList should not be empty
+      (json \ "response" \ "editorsPicks")(0).toOption should not be(None)
     }
   }
 

--- a/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
@@ -12,9 +12,8 @@ class MostViewedContainsItemsTest(context: Context) extends SanityTestBase(conte
     whenReady(httpRequest) { result =>
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
-      val mostViewedJson = (json \ "response" \ "mostViewed")
-      val mostViewedList = mostViewedJson.as[List[Map[String, String]]]
-      mostViewedList.length should be > 10
+      // most viewed length should be > 10 so try and access 11th element in list.
+      (json \ "response" \ "mostViewed")(10).toOption should not be(None)
     }
   }
 


### PR DESCRIPTION
The editors picks test was failing when trying to deserialize the json into a List[Map[String, String]].

This was no longer possible as we have introduced a new field 'isHosted' with a value of type boolean.