### PR TITLE
Play 2.6, redux

### DIFF
--- a/app/App.scala
+++ b/app/App.scala
@@ -2,31 +2,34 @@ import com.gu.contentapi.sanity._
 import com.gu.contentapi.sanity.support.{CloudWatchReporter, InfrequentScheduledTestsFailureHandler, FrequentScheduledTestFailureHandler}
 import com.gu.contentapi.sanity.utils.QuartzScheduler
 import org.joda.time.DateTime
-import scala.concurrent.duration._
+import scala.concurrent.Future, scala.concurrent.duration._
 import scala.language.postfixOps
-import play.api._
+import play.api._, play.api.inject.ApplicationLifecycle
+import play.api.libs.ws.WSClient
 
-object Global extends GlobalSettings {
+class App(
+  appLifecycle: ApplicationLifecycle,
+  cloudWatchReporter: CloudWatchReporter,
+  wsClient: WSClient) {
 
-  override def onStart(app: Application) {
-    val cloudWatchReporter = CloudWatchReporter(app.configuration)
-
+  def start = {
     Logger.info("Application has started")
     QuartzScheduler.start()
     QuartzScheduler schedule("Frequent Tests", runFrequentTests(cloudWatchReporter)) every (30 seconds)
     QuartzScheduler schedule("Infrequent Tests", runInfrequentTests(cloudWatchReporter)) at "0 0 9 ? * MON-FRI *"
-  }
 
-  override def onStop(app: Application) {
-    Logger.info("Application shutdown...")
-    QuartzScheduler.stop()
+    appLifecycle.addStopHook { () =>
+      Logger.info("Application shutdown...")
+      QuartzScheduler.stop()
+      Future.successful(())
+    }
   }
 
   def runFrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
     println(s"=== Starting frequent tests at ${new DateTime()} ===")
     val context = Context(testFailureHandler = FrequentScheduledTestFailureHandler, cloudWatchReporter = cloudWatchReporter)
-    val suites = MetaSuites.prodFrequent(context)
-    suites.foreach(_.execute)
+    val suites = MetaSuites.prodFrequent(context, wsClient)
+    suites.foreach(_.execute())
     println(s"=== Frequent tests finished at ${new DateTime()} ===")
     cloudWatchReporter.reportTestRunComplete()
   }
@@ -34,8 +37,8 @@ object Global extends GlobalSettings {
   def runInfrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
     println(s"=== Starting infrequent tests at ${new DateTime()} ===")
     val context = Context(testFailureHandler = InfrequentScheduledTestsFailureHandler, cloudWatchReporter = cloudWatchReporter)
-    val suites = MetaSuites.prodInfrequent(context)
-    suites.foreach(_.execute)
+    val suites = MetaSuites.prodInfrequent(context, wsClient)
+    suites.foreach(_.execute())
     println(s"=== Infrequent tests finished at ${new DateTime()} ===")
     cloudWatchReporter.reportTestRunComplete()
   }

--- a/app/App.scala
+++ b/app/App.scala
@@ -21,6 +21,7 @@ class App(
     appLifecycle.addStopHook { () =>
       Logger.info("Application shutdown...")
       QuartzScheduler.stop()
+      wsClient.close()
       Future.successful(())
     }
   }

--- a/app/App.scala
+++ b/app/App.scala
@@ -28,7 +28,7 @@ class App(
 
   def runFrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
     println(s"=== Starting frequent tests at ${new DateTime()} ===")
-    val context = Context(testFailureHandler = FrequentScheduledTestFailureHandler, cloudWatchReporter = cloudWatchReporter)
+    val context = Context(testFailureHandler = new FrequentScheduledTestFailureHandler(wsClient), cloudWatchReporter = cloudWatchReporter)
     val suites = MetaSuites.prodFrequent(context, wsClient)
     suites.foreach(_.execute())
     println(s"=== Frequent tests finished at ${new DateTime()} ===")
@@ -37,7 +37,7 @@ class App(
 
   def runInfrequentTests(cloudWatchReporter: CloudWatchReporter): Unit = {
     println(s"=== Starting infrequent tests at ${new DateTime()} ===")
-    val context = Context(testFailureHandler = InfrequentScheduledTestsFailureHandler, cloudWatchReporter = cloudWatchReporter)
+    val context = Context(testFailureHandler = new InfrequentScheduledTestsFailureHandler(wsClient), cloudWatchReporter = cloudWatchReporter)
     val suites = MetaSuites.prodInfrequent(context, wsClient)
     suites.foreach(_.execute())
     println(s"=== Infrequent tests finished at ${new DateTime()} ===")

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,0 +1,24 @@
+import com.gu.contentapi.sanity.support.CloudWatchReporter
+import play.api.ApplicationLoader.Context
+import play.api.{ BuiltInComponentsFromContext, NoHttpFiltersComponents }
+import play.api.inject.DefaultApplicationLifecycle
+import play.api.libs.ws.ahc.AhcWSClient
+import play.api.mvc.legacy.Controller
+import play.api.routing.Router
+import controllers.HealthcheckController
+import router.Routes
+
+class AppComponents(context: Context)
+  extends BuiltInComponentsFromContext(context)
+  with NoHttpFiltersComponents {
+
+  Controller.init(controllerComponents)
+
+  implicit val _materializer = materializer
+  val wsClient = AhcWSClient()
+
+  val app = new App(new DefaultApplicationLifecycle(), CloudWatchReporter(configuration), wsClient)
+  val router: Router = new Routes(httpErrorHandler, new HealthcheckController())
+  
+  app.start
+}

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -10,11 +10,10 @@ import router.Routes
 
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context)
-  with NoHttpFiltersComponents {
-
+  with NoHttpFiltersComponents { 
+    
   Controller.init(controllerComponents)
-
-  implicit val _materializer = materializer
+  
   val wsClient = AhcWSClient()
 
   val app = new App(new DefaultApplicationLifecycle(), CloudWatchReporter(configuration), wsClient)

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,8 +1,9 @@
+import akka.stream.ActorMaterializer
 import com.gu.contentapi.sanity.support.CloudWatchReporter
 import play.api.ApplicationLoader.Context
 import play.api.{ BuiltInComponentsFromContext, NoHttpFiltersComponents }
 import play.api.inject.DefaultApplicationLifecycle
-import play.api.libs.ws.ahc.AhcWSClient
+import play.api.libs.ws.ahc.{AhcWSComponents, AhcWSClient}
 import play.api.mvc.legacy.Controller
 import play.api.routing.Router
 import controllers.HealthcheckController
@@ -10,12 +11,13 @@ import router.Routes
 
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context)
+  with AhcWSComponents
   with NoHttpFiltersComponents { 
     
   Controller.init(controllerComponents)
-  
-  val wsClient = AhcWSClient()
 
+  override lazy val materializer = ActorMaterializer()(actorSystem)
+ 
   val app = new App(new DefaultApplicationLifecycle(), CloudWatchReporter(configuration), wsClient)
   val router: Router = new Routes(httpErrorHandler, new HealthcheckController())
   

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -16,8 +16,6 @@ class AppComponents(context: Context)
     
   Controller.init(controllerComponents)
 
-  override lazy val materializer = ActorMaterializer()(actorSystem)
- 
   val app = new App(new DefaultApplicationLifecycle(), CloudWatchReporter(configuration), wsClient)
   val router: Router = new Routes(httpErrorHandler, new HealthcheckController())
   

--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -1,0 +1,10 @@
+import play.api.libs.logback.LogbackLoggerConfigurator
+import play.api.{ Application, ApplicationLoader }
+import play.api.ApplicationLoader.Context
+
+class AppLoader extends ApplicationLoader {
+  override def load(context: Context): Application = {
+    new LogbackLoggerConfigurator().configure(context.environment)
+    new AppComponents(context).application
+  }
+}

--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -32,7 +32,7 @@ class CanaryContentSanityTest(context: Context, wsClient: WSClient) extends Sani
   "Touching the canary content" should "update the timestamp" taggedAs Retryable in {
     val postSuccessResponseCode = 202
     val httpRequest = request(Config.writeHost + "canary/content")
-      .withHeaders("Content-Type" -> "application/json")
+      .withHttpHeaders("Content-Type" -> "application/json")
       .post("")
     
     whenReady(httpRequest) { result =>

--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -5,13 +5,14 @@ import org.scalatest.tagobjects.Retryable
 import org.scalatest.time.{Seconds, Span}
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
+import play.api.libs.ws.WSClient
 
 /**
  * Performs a (nearly) end-to-end test by:
  * 1. POSTing to a special endpoint on Porter that creates a new piece of known content and pushes it to Attendant's queue
  * 2. Checking that the content shows up in Concierge with a recent lastModified timestamp
  */
-class CanaryContentSanityTest(context: Context) extends SanityTestBase(context) {
+class CanaryContentSanityTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   private def retrieveCanaryLastModifiedTimestamp(): Option[DateTime] = {
     val httpRequest = requestHost("/canary?show-fields=lastModified").get()

--- a/app/com/gu/contentapi/sanity/ContentApiSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/ContentApiSanityTest.scala
@@ -1,8 +1,9 @@
 package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
+import play.api.libs.ws.WSClient
 
-class ContentApiSanityTest(context: Context) extends SanityTestBase(context) {
+class ContentApiSanityTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "Content api" should "serve gzipped" in {
     // GZip Compression is enabled in application.conf

--- a/app/com/gu/contentapi/sanity/CriticalTagsTest.scala
+++ b/app/com/gu/contentapi/sanity/CriticalTagsTest.scala
@@ -1,8 +1,9 @@
 package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
+import play.api.libs.ws.WSClient
 
-class CriticalTagsTest(context: Context) extends SanityTestBase(context) {
+class CriticalTagsTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "Tags critical for publication (including Kindle)" should "exist" in {
     val criticalTags = Seq(

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -4,9 +4,10 @@ import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.{ProdOnly, LowPriorityTest}
 import org.joda.time.DateTime
 import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSClient
 
 @ProdOnly
-class CrosswordsIndexingTest(context: Context) extends SanityTestBase(context) {
+class CrosswordsIndexingTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "A new Crossword" should "be indexed every day" taggedAs LowPriorityTest in {
     val now = DateTime.now

--- a/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
@@ -3,9 +3,10 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.ProdOnly
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 
 @ProdOnly
-class EditorsPicksContainsItemsTest(context: Context) extends SanityTestBase(context) {
+class EditorsPicksContainsItemsTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "Editors picks for /uk" should "not be empty" in {
     val httpRequest = requestHost("/uk?show-editors-picks=true").get()

--- a/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
@@ -13,7 +13,7 @@ class EditorsPicksContainsItemsTest(context: Context, wsClient: WSClient) extend
     whenReady(httpRequest) { result =>
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
-      (json \ "response" \ "editorsPicks")(0).asOpt[String] should not be(None)
+      ((json \ "response" \ "editorsPicks")(0) \ "id").asOpt[String] should not be(None)
     }
   }
 

--- a/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/EditorsPicksContainsItemsTest.scala
@@ -12,7 +12,7 @@ class EditorsPicksContainsItemsTest(context: Context) extends SanityTestBase(con
     whenReady(httpRequest) { result =>
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
-      (json \ "response" \ "editorsPicks")(0).toOption should not be(None)
+      (json \ "response" \ "editorsPicks")(0).asOpt[String] should not be(None)
     }
   }
 

--- a/app/com/gu/contentapi/sanity/ElasticSearchSnapshotTest.scala
+++ b/app/com/gu/contentapi/sanity/ElasticSearchSnapshotTest.scala
@@ -1,14 +1,14 @@
 package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.tags.ProdOnly
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import java.time.LocalDate
 import play.api.libs.ws.WSClient
 
 @ProdOnly
 class ElasticSearchSnapshotTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
-  val s3Client: AmazonS3Client = new AmazonS3Client()
+  val s3Client: AmazonS3 = AmazonS3ClientBuilder.defaultClient()
 
     "Elasticsearch backup via snapshot" should "have been updated yesterday on S3" in {
 

--- a/app/com/gu/contentapi/sanity/ElasticSearchSnapshotTest.scala
+++ b/app/com/gu/contentapi/sanity/ElasticSearchSnapshotTest.scala
@@ -3,9 +3,10 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.tags.ProdOnly
 import com.amazonaws.services.s3.AmazonS3Client
 import java.time.LocalDate
+import play.api.libs.ws.WSClient
 
 @ProdOnly
-class ElasticSearchSnapshotTest(context: Context) extends SanityTestBase(context) {
+class ElasticSearchSnapshotTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   val s3Client: AmazonS3Client = new AmazonS3Client()
 

--- a/app/com/gu/contentapi/sanity/GetNonExistentContentShould404.scala
+++ b/app/com/gu/contentapi/sanity/GetNonExistentContentShould404.scala
@@ -1,8 +1,9 @@
 package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
+import play.api.libs.ws.WSClient
 
-class GetNonExistentContentShould404(context: Context) extends SanityTestBase(context) {
+class GetNonExistentContentShould404(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
     "GETting non existent content" should "404" in {
       val httpRequest = requestHost("foo/should-not-exist").get()

--- a/app/com/gu/contentapi/sanity/JREVersionTest.scala
+++ b/app/com/gu/contentapi/sanity/JREVersionTest.scala
@@ -3,9 +3,10 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.{ProdOnly, LowPriorityTest}
 import org.scalatest.time.{Span, Seconds}
+import play.api.libs.ws.WSClient
 
 @ProdOnly
-class JREVersionTest(context: Context) extends SanityTestBase(context) {
+class JREVersionTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   {
     "The Content API" should "be using the latest JRE" taggedAs LowPriorityTest in {

--- a/app/com/gu/contentapi/sanity/MetaSuites.scala
+++ b/app/com/gu/contentapi/sanity/MetaSuites.scala
@@ -2,33 +2,34 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.tags.ProdOnly
 import org.scalatest.Suite
+import play.api.libs.ws.WSClient
 
 object MetaSuites {
 
-  def prodFrequent(context: Context) = Seq(
-    new CanaryContentSanityTest(context),
-    new SearchContainsLargeNumberOfResults(context),
-    new PreviewRequiresAuthTest(context),
-    new ContentApiSanityTest(context),
-    new GetNonExistentContentShould404(context),
-    new ValidateArticleSchema(context),
-    new NewestItemFieldsTest(context),
-    new MostViewedContainsItemsTest(context),
-    new EditorsPicksContainsItemsTest(context),
-    new CriticalTagsTest(context),
-    new TagSearchContainsLargeNumberOfResults(context),
-    new ShowBlocksTest(context)
+  def prodFrequent(context: Context, wsClient: WSClient) = Seq(
+    new CanaryContentSanityTest(context, wsClient),
+    new SearchContainsLargeNumberOfResults(context, wsClient),
+    new PreviewRequiresAuthTest(context, wsClient),
+    new ContentApiSanityTest(context, wsClient),
+    new GetNonExistentContentShould404(context, wsClient),
+    new ValidateArticleSchema(context, wsClient),
+    new NewestItemFieldsTest(context, wsClient),
+    new MostViewedContainsItemsTest(context, wsClient),
+    new EditorsPicksContainsItemsTest(context, wsClient),
+    new CriticalTagsTest(context, wsClient),
+    new TagSearchContainsLargeNumberOfResults(context, wsClient),
+    new ShowBlocksTest(context, wsClient)
   )
 
-  def prodInfrequent(context: Context) = Seq(
+  def prodInfrequent(context: Context, wsClient: WSClient) = Seq(
     //new JREVersionTest(context), disabled for now because it spams us every day
-    new SSLExpiryTest(context),
-    new CrosswordsIndexingTest(context)
+    new SSLExpiryTest(context, wsClient),
+    new CrosswordsIndexingTest(context, wsClient)
   )
 
   /** All suites that can be run against either PROD or CODE */
-  def suitableForBothProdAndCode(context: Context) =
-    (prodFrequent(context) ++ prodInfrequent(context))
+  def suitableForBothProdAndCode(context: Context, wsClient: WSClient) =
+    (prodFrequent(context, wsClient) ++ prodInfrequent(context, wsClient))
       .filter(isNotTaggedWithProdOnly)
 
   private def isNotTaggedWithProdOnly(s: Suite): Boolean = {

--- a/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
@@ -14,7 +14,7 @@ class MostViewedContainsItemsTest(context: Context, wsClient: WSClient) extends 
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
       // most viewed length should be > 10 so try and access 11th element in list.
-      (json \ "response" \ "mostViewed")(10).asOpt[String] should not be(None)
+      ((json \ "response" \ "mostViewed")(10) \ "id").asOpt[String] should not be(None)
     }
   }
 

--- a/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
@@ -13,7 +13,7 @@ class MostViewedContainsItemsTest(context: Context) extends SanityTestBase(conte
       assume(result.status == 200, "Service is down")
       val json = Json.parse(result.body)
       // most viewed length should be > 10 so try and access 11th element in list.
-      (json \ "response" \ "mostViewed")(10).toOption should not be(None)
+      (json \ "response" \ "mostViewed")(10).asOpt[String] should not be(None)
     }
   }
 

--- a/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
+++ b/app/com/gu/contentapi/sanity/MostViewedContainsItemsTest.scala
@@ -3,9 +3,10 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.ProdOnly
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 
 @ProdOnly
-class MostViewedContainsItemsTest(context: Context) extends SanityTestBase(context) {
+class MostViewedContainsItemsTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "Most Viewed" should "contain more than 10 items" in {
     val httpRequest = requestHost("/uk?show-most-viewed=true").get()

--- a/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
+++ b/app/com/gu/contentapi/sanity/NewestItemFieldsTest.scala
@@ -2,8 +2,9 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSClient
 
-class NewestItemFieldsTest(context: Context) extends SanityTestBase(context) {
+class NewestItemFieldsTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "The newest items" should "include mandatory fields" in {
     val mandatoryItemFields = Seq[String](

--- a/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
@@ -1,8 +1,9 @@
 package com.gu.contentapi.sanity
 
 import org.scalatest.time.{Seconds, Span}
+import play.api.libs.ws.WSClient
 
-class PreviewRequiresAuthTest(context: Context) extends SanityTestBase(context) {
+class PreviewRequiresAuthTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "GETting preview content" should "require authentication" in {
     //Sometimes this throws a java.io.IOException, with message: Remotely Closed, so using Eventually to retry

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -2,6 +2,7 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.{ProdOnly, LowPriorityTest}
+import play.api.libs.ws.WSClient
 
 import scala.util.{Success, Failure}
 import javax.net.ssl._
@@ -12,7 +13,7 @@ import sun.security.x509.X509CertImpl
 import scala.util.Try
 
 @ProdOnly
-class SSLExpiryTest(context: Context) extends SanityTestBase(context) {
+class SSLExpiryTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "SSL Certificates" should "be more than 30 days from expiry" taggedAs LowPriorityTest in {
     val hosts = Seq(

--- a/app/com/gu/contentapi/sanity/SanityTestBase.scala
+++ b/app/com/gu/contentapi/sanity/SanityTestBase.scala
@@ -3,8 +3,9 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support._
 import org.scalatest.{Matchers, OptionValues, Retries, FlatSpec}
 import org.scalatest.concurrent.{ScalaFutures, IntegrationPatience, Eventually}
+import play.api.libs.ws.WSClient
 
-abstract class SanityTestBase(context: Context)
+abstract class SanityTestBase(context: Context, override val wsClient: WSClient)
   extends FlatSpec with Matchers with OptionValues
   with Eventually with Retries with ScalaFutures with IntegrationPatience
   with TestFailureHandlingSupport with CloudWatchReportingSupport

--- a/app/com/gu/contentapi/sanity/SearchContainsLargeNumberOfResults.scala
+++ b/app/com/gu/contentapi/sanity/SearchContainsLargeNumberOfResults.scala
@@ -3,9 +3,10 @@ package com.gu.contentapi.sanity
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.ProdOnly
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 
 @ProdOnly
-class SearchContainsLargeNumberOfResults(context: Context) extends SanityTestBase(context) {
+class SearchContainsLargeNumberOfResults(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "The Content API" should "return a large total of results on the /search endpoint" in {
     val httpRequest = requestHost("search").get()

--- a/app/com/gu/contentapi/sanity/ShowBlocksTest.scala
+++ b/app/com/gu/contentapi/sanity/ShowBlocksTest.scala
@@ -2,8 +2,9 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.{JsArray, JsValue, Json}
+import play.api.libs.ws.WSClient
 
-class ShowBlocksTest(context: Context) extends SanityTestBase(context) {
+class ShowBlocksTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "The newest Flex items in the search results" should "include blocks if show-blocks=all" in {
 

--- a/app/com/gu/contentapi/sanity/TagSearchContainsLargeNumberOfResults.scala
+++ b/app/com/gu/contentapi/sanity/TagSearchContainsLargeNumberOfResults.scala
@@ -2,8 +2,9 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 
-class TagSearchContainsLargeNumberOfResults(context: Context) extends SanityTestBase(context) {
+class TagSearchContainsLargeNumberOfResults(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "The Content API" should "return a large total of tags on the /tags endpoint" in {
     val httpRequest = requestHost("tags").get()

--- a/app/com/gu/contentapi/sanity/ValidateArticleSchema.scala
+++ b/app/com/gu/contentapi/sanity/ValidateArticleSchema.scala
@@ -2,8 +2,9 @@ package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.TestFailureHandler
 import play.api.libs.json.Json
+import play.api.libs.ws.WSClient
 
-class ValidateArticleSchema(context: Context) extends SanityTestBase(context) {
+class ValidateArticleSchema(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "The Content API" should "return correct article schema" in {
     val httpRequest = requestHost("/lifeandstyle/lostinshowbiz/2014/sep/18/charlotte-crosby-blueprint-for-civilisation-geordie-shore-celebrity-big-brother?show-fields=all&show-elements=all").get()

--- a/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
@@ -37,7 +37,7 @@ trait CloudWatchReporter {
 object CloudWatchReporter {
 
   def apply(config: Configuration): CloudWatchReporter = {
-    def cfg(key: String) = config.getString(s"content-api-sanity-tests.cloudwatch-$key")
+    def cfg(key: String) = config.getOptional[String](s"content-api-sanity-tests.cloudwatch-$key")
     val reporter = for {
       namespace <- cfg("namespace")
       testRunsMetric <- cfg("test-runs-metric")

--- a/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
@@ -5,12 +5,12 @@ import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchAsyncClientBuilder}
 import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, PutMetricDataResult}
-import org.scalatest.{Failed, Outcome, Succeeded, Suite}
+import org.scalatest.{Failed, Outcome, Succeeded, TestSuite}
 import play.api.{Configuration, Logger}
 
 import scala.util.Try
 
-trait CloudWatchReportingSupport extends Suite {
+trait CloudWatchReportingSupport extends TestSuite {
 
   def cloudWatchReporter: CloudWatchReporter
 

--- a/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/HttpRequestSupport.scala
@@ -4,13 +4,15 @@ import com.gu.contentapi.sanity.Config
 import org.scalatest.exceptions.TestPendingException
 import org.scalatest.{Assertions, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import play.api.libs.ws.{WSResponse, WSAuthScheme, WS, WSRequest}
+import play.api.libs.ws.{WSClient, WSResponse, WSAuthScheme, WSRequest}
 import play.api.Play.current
 import scala.concurrent.duration._
 
 trait HttpRequestSupport extends ScalaFutures with Matchers with Assertions {
 
-  def request(uri: String): WSRequest = WS.url(uri).withRequestTimeout(10000.millis)
+  def wsClient: WSClient
+
+  def request(uri: String): WSRequest = wsClient.url(uri).withRequestTimeout(10000.millis)
 
   def requestHost(path: String) =
     // make sure query string is included

--- a/app/com/gu/contentapi/sanity/support/TestFailureHandlingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/TestFailureHandlingSupport.scala
@@ -5,6 +5,7 @@ import org.joda.time.{DateTime, Minutes}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest._
 import play.api.libs.json.{JsValue, Json}
+import play.api.libs.ws.WSClient
 
 /**
  * Contains all the test failure handling logic:
@@ -32,7 +33,7 @@ trait TestFailureHandler {
 
 }
 
-abstract class PagerDutyAlertingTestFailureHandler
+abstract class PagerDutyAlertingTestFailureHandler(override val wsClient: WSClient)
   extends TestFailureHandler with HttpRequestSupport with Matchers with ScalaFutures with IntegrationPatience with OptionValues {
   import PagerDutyAlertingTestFailureHandler._
 
@@ -104,7 +105,7 @@ object PagerDutyAlertingTestFailureHandler {
  * Note that this handler holds state about failure counts that needs to be shared across multiple suites
  * and even across multiple runs of the scheduler.
  */
-object FrequentScheduledTestFailureHandler extends PagerDutyAlertingTestFailureHandler {
+class FrequentScheduledTestFailureHandler(wsClient: WSClient) extends PagerDutyAlertingTestFailureHandler(wsClient) {
 
   /**
    * How long to wait between failed tests before resetting the incident counter
@@ -154,7 +155,7 @@ object FrequentScheduledTestFailureHandler extends PagerDutyAlertingTestFailureH
 /**
  * Handler that sends a PagerDuty alert immediately
  */
-object InfrequentScheduledTestsFailureHandler extends PagerDutyAlertingTestFailureHandler {
+class InfrequentScheduledTestsFailureHandler(wsClient: WSClient) extends PagerDutyAlertingTestFailureHandler(wsClient) {
 
   override def handleTestFailure(testName: String, exception: Throwable, tags: Set[String]): Unit = {
     Console.err.println(Console.RED + "Test failure: " + exception.getMessage + Console.RESET)

--- a/app/com/gu/contentapi/sanity/support/TestFailureHandlingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/TestFailureHandlingSupport.scala
@@ -11,7 +11,7 @@ import play.api.libs.json.{JsValue, Json}
  *  - counting test failures
  *  - sending PagerDuty alerts
  */
-trait TestFailureHandlingSupport extends Suite {
+trait TestFailureHandlingSupport extends TestSuite {
 
   def testFailureHandler: TestFailureHandler
 

--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -1,0 +1,24 @@
+package play.api.mvc.legacy
+
+import play.api.mvc._
+
+class Controller extends BaseController {
+
+  override protected def controllerComponents: ControllerComponents = {
+    Controller.components /* we don't null check here to avoid the cost associated to it - we expect dev to have done the init properly */
+  }
+
+}
+
+object Controller {
+
+    private var components: ControllerComponents = null
+
+    /**
+     * This need to be called when you initialise the app in app compoments
+     */
+    def init(c: ControllerComponents) = {
+      components = c
+    }
+
+}

--- a/app/controllers/HealthcheckController.scala
+++ b/app/controllers/HealthcheckController.scala
@@ -1,9 +1,10 @@
 package controllers
 
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.Action
+import play.api.mvc.legacy.Controller
 
-object HealthcheckController extends Controller {
-  def report() = Action { request =>
+class HealthcheckController extends Controller {
+  def report() = Action {
     Ok("heartbeat")
   }
 }

--- a/app/deploy/riff-raff.yaml
+++ b/app/deploy/riff-raff.yaml
@@ -7,6 +7,7 @@ deployments:
     type: autoscaling
     parameters:
       bucket: content-api-sanity-tests-dist
+    dependencies: [sanity-tests-ami-update]
   sanity-tests-ami-update:
     type: ami-cloudformation-parameter
     parameters:
@@ -17,4 +18,3 @@ deployments:
       prependStackToCloudFormationStackName: false
       appendStageToCloudFormationStackName: true
       cloudFormationStackByTags: false
-    dependencies: [sanity-tests]

--- a/build.sbt
+++ b/build.sbt
@@ -10,17 +10,17 @@ routesGenerator := StaticRoutesGenerator
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-val AwsVersion = "1.11.97"
+val AwsVersion = "1.11.227"
 
 libraryDependencies ++= Seq(
-  "org.quartz-scheduler" % "quartz" % "2.1.6",
-  "org.scalatest" %% "scalatest" % "2.2.6",
-  "org.seleniumhq.selenium" % "selenium-java" % "2.41.0",
-  "joda-time" % "joda-time" % "2.7",
+  "org.quartz-scheduler" % "quartz" % "2.3.0",
+  "org.scalatest" %% "scalatest" % "3.0.4",
+  "org.seleniumhq.selenium" % "selenium-java" % "3.5.3",
+  "joda-time" % "joda-time" % "2.9.9",
   ws,
   "com.github.scala-incubator.io" %% "scala-io-core" % "0.4.3",
   "com.github.scala-incubator.io" %% "scala-io-file" % "0.4.3",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % AwsVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % AwsVersion
 )

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,11 @@ scalaVersion := "2.11.11"
 
 scalacOptions ++= Seq("-feature")
 
-routesGenerator := StaticRoutesGenerator
+routesGenerator := InjectedRoutesGenerator
 
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+lazy val root = (project in file("."))
+  .enablePlugins(PlayScala, PlayAkkaHttpServer)
+  .disablePlugins(PlayNettyServer)
 
 val AwsVersion = "1.11.227"
 
@@ -24,8 +26,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % AwsVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % AwsVersion
 )
-
-parallelExecution in ThisBuild := false
 
 javaOptions ++= collection.JavaConversions.propertiesAsScalaMap(System.getProperties).map{ case (key,value) => "-D" + key + "=" +value }.toSeq
 

--- a/conf/application.conf.sample
+++ b/conf/application.conf.sample
@@ -3,6 +3,8 @@ play.ws.compressionEnabled=true
 # Don't pool WS client connections for more than a minute
 play.ws.ahc.maxConnectionLifetime = 1 minute
 
+play.application.loader = AppLoader
+
 # these are our own config values defined by the app
 # rename this to application.conf with real values
 content-api-sanity-tests {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/sanity-tests.service
+++ b/sanity-tests.service
@@ -7,7 +7,7 @@ Group=content-api
 Restart=no
 WorkingDirectory=/home/content-api/sanity-tests
 
-Environment='JAVA_OPTS=-XX:+UseConcMarkSweepGC -XX:NewRatio=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -Dconfig.file=/etc/gu/content-api-sanity-tests.conf'
+Environment='JAVA_OPTS=-Xmx256m -Xms256m -XX:+UseConcMarkSweepGC -XX:NewRatio=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -Dconfig.file=/etc/gu/content-api-sanity-tests.conf'
 
 ExecStart=/bin/bash -c 'bin/sanity-tests >> /home/content-api/logs/sanity-tests.log 2>&1'
 

--- a/sanity-tests.service
+++ b/sanity-tests.service
@@ -7,7 +7,7 @@ Group=content-api
 Restart=no
 WorkingDirectory=/home/content-api/sanity-tests
 
-Environment='JAVA_OPTS=-Xmx256m -Xms256m -XX:+UseConcMarkSweepGC -XX:NewRatio=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -Dconfig.file=/etc/gu/content-api-sanity-tests.conf'
+Environment='JAVA_OPTS=-Xmx512m -Xms512m -XX:+UseConcMarkSweepGC -XX:NewRatio=2 -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -Dconfig.file=/etc/gu/content-api-sanity-tests.conf'
 
 ExecStart=/bin/bash -c 'bin/sanity-tests >> /home/content-api/logs/sanity-tests.log 2>&1'
 

--- a/test/com/gu/contentapi/sanity/CODESuite.scala
+++ b/test/com/gu/contentapi/sanity/CODESuite.scala
@@ -1,14 +1,16 @@
 package com.gu.contentapi.sanity
 
 import com.gu.contentapi.sanity.support.{FakeAppSupport, DoNothingTestFailureHandler}
-import org.scalatest.Suites
+import org.scalatest.{TestSuite, Suites} 
+import play.api.libs.ws.WSClient
 
 /**
  * Nested suite of all the tests that should be run in the CODE environment
  */
-class CODESuite extends Suites(
+class CODESuite(wsClient: WSClient) extends Suites(
   CODESuite.CodeOnlySuites ++
-  MetaSuites.suitableForBothProdAndCode(context = Context.Testing): _*) with FakeAppSupport
+  MetaSuites.suitableForBothProdAndCode(context = Context.Testing, wsClient): _*) 
+  with TestSuite
 
 object CODESuite {
 

--- a/test/com/gu/contentapi/sanity/support/FakeAppSupport.scala
+++ b/test/com/gu/contentapi/sanity/support/FakeAppSupport.scala
@@ -1,14 +1,13 @@
 package com.gu.contentapi.sanity.support
 
-import org.scalatest.{TestData, Suite}
-import org.scalatestplus.play.{OneAppPerTest, OneAppPerSuite}
-import play.api.test.FakeApplication
+import org.scalatest.{TestData, TestSuite}
+import org.scalatestplus.play.FakeApplicationFactory
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.ws.ahc.AhcWSClient
 
-trait FakeAppSupport extends OneAppPerSuite { self: Suite =>
+trait FakeAppSupport extends GuiceOneAppPerSuite with FakeApplicationFactory { self: TestSuite =>
 
-  override implicit lazy val app = new FakeApplication(
-    // don't trip up on the Guardian self-signed certificate in CODE
-    additionalConfiguration = Map("ws.acceptAnyCertificate" -> true))
-
+  override implicit lazy val app = fakeApplication()
+  
 }
 

--- a/test/com/gu/contentapi/sanity/support/FakeAppSupport.scala
+++ b/test/com/gu/contentapi/sanity/support/FakeAppSupport.scala
@@ -2,16 +2,11 @@ package com.gu.contentapi.sanity.support
 
 import org.scalatest.{TestData, Suite}
 import org.scalatestplus.play.{OneAppPerTest, OneAppPerSuite}
-import play.api.GlobalSettings
 import play.api.test.FakeApplication
 
 trait FakeAppSupport extends OneAppPerSuite { self: Suite =>
 
   override implicit lazy val app = new FakeApplication(
-
-    // override Global so that we don't start the Quartz scheduler
-    withGlobal = Some(new GlobalSettings {}),
-
     // don't trip up on the Guardian self-signed certificate in CODE
     additionalConfiguration = Map("ws.acceptAnyCertificate" -> true))
 


### PR DESCRIPTION
This time I conjure up a `WSClient` at the application point so I can use the existing `Materializer` instead of creating a new one for each test instance. Also the client is shared across all tests, it makes it easier to deal with resource cleanup.