### PR TITLE
Support api-gateway authorisation response

### DIFF
--- a/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
+++ b/app/com/gu/contentapi/sanity/PreviewRequiresAuthTest.scala
@@ -11,7 +11,7 @@ class PreviewRequiresAuthTest(context: Context, wsClient: WSClient) extends Sani
       val httpRequest = request(Config.previewHost).get()
       whenReady(httpRequest) { result =>
         assumeNotInsideEventually(503, 504)(result)
-        result.status should be(401)
+        result.status should (be(401) or be(403))
 
       }
     }


### PR DESCRIPTION
One of the sanity-tests simply hits capi preview and checks that it returns a Not Authorised response.
I've updated the s3 config to use the new url.
This change makes it accept a 403 response as well as 401. Api gateway returns a 403 even if you provide no authorisation header, which is [technically incorrect](https://en.wikipedia.org/wiki/HTTP_403#Difference_from_status_%22401_Unauthorized%22)