### PR TITLE
Remove unnecessary parameter in riffraff (default is true)

### DIFF
--- a/app/deploy/riff-raff.yaml
+++ b/app/deploy/riff-raff.yaml
@@ -16,5 +16,4 @@ deployments:
         AmigoStage: PROD
       cloudFormationStackName: content-api-sanity-tests
       prependStackToCloudFormationStackName: false
-      appendStageToCloudFormationStackName: true
       cloudFormationStackByTags: false


### PR DESCRIPTION
to make the big red warning go away