### PR TITLE
Add support for Wazuh agent and move to Ubuntu Bionic AMI

### DIFF
--- a/app/deploy/riff-raff.yaml
+++ b/app/deploy/riff-raff.yaml
@@ -13,6 +13,6 @@ deployments:
     app: sanity-tests
     parameters:
       amiTags:
-        Recipe: ubuntu-xenial-java8
+        Recipe: ubuntu-bionic-capi
         AmigoStage: PROD
       amiEncrypted: true

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -77,6 +77,30 @@ Resources:
           - arn:aws:s3::*:content-api-es-snapshots/*
       Roles:
       - !Ref Role
+  DescribeInstancesPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: ec2:DescribeInstances
+            Effect: Allow
+            Resource: '*'
+      PolicyName: ec2-describe-instances
+      Roles:
+        - !Ref Role
+  Ec2DescribeAutoScalingGroupsPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ec2-describe-autoscaling-groups
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - autoscaling:DescribeAutoScalingGroups
+              - autoscaling:DescribeAutoScalingInstances
+            Resource: "*"
+      Roles:
+        - Ref Role
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -131,6 +155,7 @@ Resources:
       AssociatePublicIpAddress: true
       SecurityGroups: 
       - !Ref SecurityGroup
+      - !Ref WazuhSecurityGroup
       InstanceType: t3.micro
       IamInstanceProfile: !Ref InstanceProfile
       UserData:
@@ -194,6 +219,17 @@ Resources:
         FromPort: '22'
         ToPort: '22'
         CidrIp: 77.91.248.0/21
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
+      VpcId:
+        !Ref VPC
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 1514
+          ToPort: 1515
+          CidrIp: 0.0.0.0/0
   NotEnoughSuccessfulTestsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -100,7 +100,7 @@ Resources:
               - autoscaling:DescribeAutoScalingInstances
             Resource: "*"
       Roles:
-        - Ref Role
+        - !Ref Role
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
This PR makes some changes to the security configuration of the launch config for the apps auto scale group.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

his is to support enabling the Wazuh vulnerability scanner agent. For more details see:

https://github.com/guardian/security-hq/blob/main/hq/markdown/wazuh.md

The changes to the security config are as follows:

- Adding a security group to allow network connections from the agent to the Wazuh service.
- Allowing read permissions on the autoscale group to allow the wazuh agent to collect information about the ASG.

NOTE: In addition to these changes we need to update the AMI configured in the Crier launch configuration to an AMI that has the Wazuh profile:

https://amigo.gutools.co.uk/recipes/ubuntu-bionic-capi

~~This is configured manually in the stack parameters when deploying the cloudformation template:~~

<img width="795" alt="Screenshot 2021-04-27 at 14 33 49" src="https://user-images.githubusercontent.com/289928/116250446-a4010d80-a765-11eb-91f9-b1f491693b7f.png">

**Edit [JP]:** We should be able to specify the recipe via our riff-raff.yaml file rather than rely on manual updates to the cloudformation stack's parameters.

## How to test

This change should mean the content-api-sanity-tests instances show up on the Wazuh dashboard but this is only accessible to the infosec team.

You can see the status of the wazuh agent using the following command:

 ssm cmd -c "service wazuh-agent status | grep Active && journalctl -u wazuh-agent | grep -E \"(Valid|error)\"" -t sanity-tests,content-api-sanity-tests,PROD -p capi
