### PR TITLE
Fix build

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,8 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
+// The Typesafe repository
+resolvers += Resolver.typesafeRepo("releases")
+
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,5 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
-resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")


### PR DESCRIPTION
This change just update the resolver to the typesafe repo to use the predefined resolver supplied with sbt.

This fixes the reference to the http version of the repo which has been taken out of service:

https://www.lightbend.com/blog/lightbend-to-require-https-on-repos-starting-august-5-2020