### PR TITLE
Replace deprecated `bucket` riff-raff parameter

### DIFF
--- a/app/deploy/riff-raff.yaml
+++ b/app/deploy/riff-raff.yaml
@@ -6,6 +6,7 @@ deployments:
   sanity-tests:
     type: autoscaling
     parameters:
+      bucketSsmKey: /account/services/artifact.bucket.sanity-tests
       bucketSsmLookup: true
     dependencies: [sanity-tests-ami-update]
   sanity-tests-ami-update:

--- a/app/deploy/riff-raff.yaml
+++ b/app/deploy/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
   sanity-tests:
     type: autoscaling
     parameters:
-      bucket: content-api-sanity-tests-dist
+      bucketSsmLookup: true
     dependencies: [sanity-tests-ami-update]
   sanity-tests-ami-update:
     type: ami-cloudformation-parameter


### PR DESCRIPTION
The `bucket` parameter in riff-raff.yaml has been deprecated in favour of `bucketSsmLookup`.  This causes Riffraff to look up the destination bucket from a parameter in the AWS account's SSM parameter store instead of being hard-coded.  We are currently getting deprecation warnings when deploying this project in riffraff, and merging this PR should fix that by replacing the deprecated parameter with the new one.