### PR TITLE
Bump various libs to address vulnerabilities identified by Snyk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ lazy val root = (project in file("."))
 val AwsVersion = "1.11.227"
 
 libraryDependencies ++= Seq(
-  "org.quartz-scheduler" % "quartz" % "2.3.0",
+  "org.quartz-scheduler" % "quartz" % "2.3.1",
   "org.scalatest" %% "scalatest" % "3.0.4",
-  "org.seleniumhq.selenium" % "selenium-java" % "3.5.3",
+  "org.seleniumhq.selenium" % "selenium-java" % "3.6.0",
   "joda-time" % "joda-time" % "2.9.9",
   ws,
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.19")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 


### PR DESCRIPTION
## What does this change?

Upgrade to org.quartz-scheduler:quartz@2.3.1
Upgrade to org.seleniumhq.selenium:selenium-java@3.6.0
Upgrade to com.typesafe.play:play-server_2.12@2.6.19

[View this project in Snyk](https://app.snyk.io/org/guardian-capi/project/6a044442-c52f-48cb-aaaf-edc1761e9f68)