### PR TITLE
Bugfix - switch out LocalDateTime for ZonedDateTime

### DIFF
--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.tagobjects.Retryable
 import org.scalatest.time.{Seconds, Span}
 import play.api.libs.ws.WSClient
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 /**
  * Performs a (nearly) end-to-end test by:
@@ -14,11 +14,11 @@ import java.time.LocalDateTime
  */
 class CanaryContentSanityTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
-  private def retrieveCanaryLastModifiedTimestamp(): Option[LocalDateTime] = {
+  private def retrieveCanaryLastModifiedTimestamp(): Option[ZonedDateTime] = {
     val httpRequest = requestHost("/canary?show-fields=lastModified").get()
     whenReady(httpRequest) { result =>
       val stringValue = (result.json \ "response" \ "content" \ "fields" \ "lastModified").asOpt[String]
-      stringValue.map(LocalDateTime.parse)
+      stringValue.map(ZonedDateTime.parse)
     }
   }
 
@@ -41,7 +41,7 @@ class CanaryContentSanityTest(context: Context, wsClient: WSClient) extends Sani
         result.status should equal(postSuccessResponseCode)
       }
 
-      val thirtySecondsAgo = LocalDateTime.now.minusSeconds(30)
+      val thirtySecondsAgo = ZonedDateTime.now.minusSeconds(30)
       eventually(timeout(Span(30, Seconds))) {
         val lastModified = retrieveCanaryLastModifiedTimestamp()
         withClue(s"Canary content did not show a lastModified >= $thirtySecondsAgo. lastModified field was $lastModified") {

--- a/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
+++ b/app/com/gu/contentapi/sanity/CrosswordsIndexingTest.scala
@@ -4,14 +4,13 @@ import com.gu.contentapi.sanity.support.TestFailureHandler
 import com.gu.contentapi.sanity.tags.{LowPriorityTest, ProdOnly}
 import play.api.libs.json.{JsValue, Json}
 import play.api.libs.ws.WSClient
-
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 @ProdOnly
 class CrosswordsIndexingTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   "A new Crossword" should "be indexed every day" taggedAs LowPriorityTest in {
-    val now = LocalDateTime.now
+    val now = ZonedDateTime.now
 
     val isAfterChristmas = now.getMonthValue == 12 && (now.getDayOfMonth == 26 || now.getDayOfMonth == 27)
     val twentyFiveHoursAgo = now.minusHours(25)
@@ -27,7 +26,7 @@ class CrosswordsIndexingTest(context: Context, wsClient: WSClient) extends Sanit
       }
       newestItemOpt foreach { newestItem =>
         val newestItemDateString = (newestItem \ "webPublicationDate").asOpt[String]
-        val newestItemDate = LocalDateTime.parse(newestItemDateString.value)
+        val newestItemDate = ZonedDateTime.parse(newestItemDateString.value)
         withClue(s"Latest indexed crossword was at $newestItemDate which is more than 25 hours ago ($twentyFiveHoursAgo)") {
           newestItemDate.isAfter(twentyFiveHoursAgo) should be(true)
         }

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -9,7 +9,7 @@ import javax.net.ssl._
 import java.net.URL
 import sun.security.x509.X509CertImpl
 
-import java.time.{Duration, LocalDateTime}
+import java.time.{Duration, LocalDateTime, ZonedDateTime}
 import scala.util.Try
 
 @ProdOnly
@@ -51,7 +51,7 @@ class SSLExpiryTest(context: Context, wsClient: WSClient) extends SanityTestBase
             cert shouldBe a[X509CertImpl]
             val x = cert.asInstanceOf[X509CertImpl]
             val expiry = x.getNotAfter.toInstant
-            val daysleft = Duration.between(LocalDateTime.now(), expiry).toDays
+            val daysleft = Duration.between(ZonedDateTime.now(), expiry).toDays
             if (daysleft < 30) {
               fail("Cert for %s expires in %d days".format(host, daysleft))
             }

--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -9,7 +9,7 @@ import javax.net.ssl._
 import java.net.URL
 import sun.security.x509.X509CertImpl
 
-import java.time.{Duration, LocalDateTime, ZonedDateTime}
+import java.time.{Duration, ZonedDateTime}
 import scala.util.Try
 
 @ProdOnly


### PR DESCRIPTION
## What does this change?

- Replaces usages of LocalDateTime with ZonedDateTime. This is because (a) you can't parse a timestamp with a zone identifier - even just `Z` - into a LocalDateTime and (b) you can't compare a LocalDateTime with a ZonedDateTime. Both result in exceptions => failed tests.

## How to test

Deploy it and check that the tests stop failing - test results can be graphed here: https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(metrics~(~(~'content-api-sanity-tests~'FailedTests)~(~'.~'TestRuns)~(~'.~'SuccessfulTests))~view~'timeSeries~stacked~false~region~'eu-west-1~stat~'Sum~period~60);query=~'*7bcontent-api-sanity-tests*7d

## How can we measure success?

Less failing tests

## Have we considered potential risks?

n/a. Tested on CODE.
