### PR TITLE
Fix for SSL verify issue

### DIFF
--- a/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
+++ b/app/com/gu/contentapi/sanity/SSLExpiryTest.scala
@@ -51,7 +51,7 @@ class SSLExpiryTest(context: Context, wsClient: WSClient) extends SanityTestBase
             cert shouldBe a[X509CertImpl]
             val x = cert.asInstanceOf[X509CertImpl]
             val expiry = x.getNotAfter.toInstant
-            val daysleft = Duration.between(ZonedDateTime.now(), expiry).toDays
+            val daysleft = Duration.between(ZonedDateTime.now().toInstant, expiry).toDays
             if (daysleft < 30) {
               fail("Cert for %s expires in %d days".format(host, daysleft))
             }

--- a/cdk/instance-startup.sh
+++ b/cdk/instance-startup.sh
@@ -13,8 +13,5 @@ systemctl stop sanity-tests #just in case it gets auto-started!
 aws --region eu-west-1 s3 cp 's3://content-api-config/content-api-sanity-tests/${Stage}/sanity-tests/content-api-sanity-tests.conf' /usr/share/sanity-tests/conf/content-api-sanity-tests.conf
 ln -s /usr/share/sanity-tests /home/content-api/sanity-tests
 echo JAVA_OPTS=\"-Dpidfile.path=/var/run/sanity-tests/sanity-tests.pid -Dconfig.file=/usr/share/sanity-tests/conf/content-api-sanity-tests.conf -Dplay.http.secret.key=kkMQbRpa1ttyM0oXwlyPwd5ODNeFMv63h452itOGzWulEUipJjMfm73\" >> /etc/default/sanity-tests
-# shellcheck disable=SC2016
-sed 's/{logging-stream}/${LoggingStreamName}/' </usr/share/sanity-tests/conf/logback.xml > /usr/share/sanity-tests/conf/logback-updated.xml
-mv /usr/share/sanity-tests/conf/logback-updated.xml /usr/share/sanity-tests/conf/logback.xml
 
 systemctl start sanity-tests

--- a/cdk/lib/__snapshots__/sanity-tests.test.ts.snap
+++ b/cdk/lib/__snapshots__/sanity-tests.test.ts.snap
@@ -190,11 +190,7 @@ exports[`The SanityTests stack matches the snapshot 1`] = `
           },
         ],
         "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -ev
+          "Fn::Base64": "#!/bin/bash -ev
 
 adduser --disabled-password content-api
 
@@ -209,18 +205,8 @@ systemctl stop sanity-tests #just in case it gets auto-started!
 aws --region eu-west-1 s3 cp 's3://content-api-config/content-api-sanity-tests/TEST/sanity-tests/content-api-sanity-tests.conf' /usr/share/sanity-tests/conf/content-api-sanity-tests.conf
 ln -s /usr/share/sanity-tests /home/content-api/sanity-tests
 echo JAVA_OPTS=\\"-Dpidfile.path=/var/run/sanity-tests/sanity-tests.pid -Dconfig.file=/usr/share/sanity-tests/conf/content-api-sanity-tests.conf -Dplay.http.secret.key=kkMQbRpa1ttyM0oXwlyPwd5ODNeFMv63h452itOGzWulEUipJjMfm73\\" >> /etc/default/sanity-tests
-# shellcheck disable=SC2016
-sed 's/{logging-stream}/",
-                {
-                  "Ref": "LoggingStreamName",
-                },
-                "/' </usr/share/sanity-tests/conf/logback.xml > /usr/share/sanity-tests/conf/logback-updated.xml
-mv /usr/share/sanity-tests/conf/logback-updated.xml /usr/share/sanity-tests/conf/logback.xml
 
 systemctl start sanity-tests",
-              ],
-            ],
-          },
         },
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",


### PR DESCRIPTION
## What does this change?

- Try to fix the SSL verify issue by ensuring we are comparing like-for-like temporal expressions in `Duration.between()`
- Remove pointless logback config customisation

## How to test

- Deploy to live
- Hope that the SSL alert does not fire in the morning :)

## How can we measure success?

Tests working properly

## Have we considered potential risks?

n/a
