### PR TITLE
Get canary content from channel

### DIFF
--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -15,7 +15,9 @@ import java.time.ZonedDateTime
 class CanaryContentSanityTest(context: Context, wsClient: WSClient) extends SanityTestBase(context, wsClient) {
 
   private def retrieveCanaryLastModifiedTimestamp(): Option[ZonedDateTime] = {
-    val httpRequest = requestHost("/canary?show-fields=lastModified").get()
+    // since channels became possible - canary content is now hidden from the world by default and
+    // only accessible from the /channel/canary path :)
+    val httpRequest = requestHost("/channel/canary?show-fields=lastModified").get()
     whenReady(httpRequest) { result =>
       val stringValue = (result.json \ "response" \ "content" \ "fields" \ "lastModified").asOpt[String]
       stringValue.map(ZonedDateTime.parse)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Now that channels are live, canary content is written to the canary channel by default by Porter. In order for sanity tests to get it back again, it must ask for the appropriate channel content as it's no longer accessible via normal routes.

## How to test

Watch the logs. The 404 rate for `/canary` `GET` requests should drop back to pre-channel levels.

## How can we measure success?

No more (unexpected) 404s

## Have we considered potential risks?

Nothing to worry about. Unless we roll back channels again.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] Not applicable - there is no UI here
