### PR TITLE
Attempt to fix canary test

### DIFF
--- a/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
+++ b/app/com/gu/contentapi/sanity/CanaryContentSanityTest.scala
@@ -19,7 +19,7 @@ class CanaryContentSanityTest(context: Context, wsClient: WSClient) extends Sani
     // only accessible from the /channel/canary path :)
     val httpRequest = requestHost("/channel/canary?show-fields=lastModified").get()
     whenReady(httpRequest) { result =>
-      val stringValue = (result.json \ "response" \ "content" \ "fields" \ "lastModified").asOpt[String]
+      val stringValue = (result.json \ "response" \ "results" \ 0 \ "fields" \ "lastModified").asOpt[String]
       stringValue.map(ZonedDateTime.parse)
     }
   }


### PR DESCRIPTION
## What does this change?

This PR is a small follow-up to https://github.com/guardian/content-api-sanity-tests/pull/123. 

The PR attempts to fix a failing test. The [logs](https://logs.gutools.co.uk/s/content-platforms/goto/462efe00-e35a-11ed-9a16-b97a35e659c0) suggest that the `lastModified` date cannot be found when parsing the JSON response and consequently this test is currently failing.

I have made the API call locally and can see that the JSON body looks slightly different to the response that the test is expecting:

```
{
  "response": {
    "status": "ok",
    "userTier": "internal",
    "total": 1,
    "startIndex": 1,
    "pageSize": 10,
    "currentPage": 1,
    "pages": 1,
    "orderBy": "newest",
    "results": [
      {
        "id": "canary",
        "type": "article",
        "sectionId": "global",
        "sectionName": "Global",
        "webPublicationDate": "2015-04-28T12:34:56Z",
        "webTitle": "Canary content",
        "webUrl": "https://www.theguardian.com/canary",
        "apiUrl": "https://content.guardianapis.com/canary",
        "fields": {
          "lastModified": "2023-04-24T16:06:00Z"
        },
        "isHosted": false
      }
    ]
  }
}
```

## How to test

I've tested the JSON parsing locally using a simple test project.

## How can we measure success?

We should be able to see whether this fix works as expected by checking logs/metrics.

## Have we considered potential risks?

I can't think of any particular risks associated with this PR.