### PR TITLE
Bump aws-sdk to 2.21.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala, PlayAkkaHttpServer)
   .disablePlugins(PlayNettyServer)
 
-val AwsVersion = "2.18.27"
+val AwsVersion = "2.21.10"
 
 libraryDependencies ++= Seq(
   "org.quartz-scheduler" % "quartz" % "2.3.2",


### PR DESCRIPTION
## What does this change?

Bumps aws-sdk to 2.21.2 and netty-codec-http2 to 4.1.100, to fix a [high vulnerability in Snyk.](https://app.snyk.io/org/guardian-capi/project/6317798d-c26e-456a-84dc-8df25c949d53/history/6c710e83-8973-47c2-ad51-fec9ab4b1e5c#issue-SNYK-JAVA-IONETTY-5953332)

## How to test

The [generated Snyk report](https://app.snyk.io/org/guardian-capi/project/6317798d-c26e-456a-84dc-8df25c949d53/history/482c74b6-d377-4b63-9aa5-837b3fc74400) shows that the vulnerability is gone.