### PR TITLE
Fix snyk high vuln in akka-http-core (moving from akka to pekko)

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,4 +1,4 @@
-import akka.stream.ActorMaterializer
+import org.apache.pekko.stream.ActorMaterializer
 import com.gu.contentapi.sanity.support.CloudWatchReporter
 import play.api.ApplicationLoader.Context
 import play.api.{ BuiltInComponentsFromContext, NoHttpFiltersComponents }

--- a/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
+++ b/app/com/gu/contentapi/sanity/support/CloudWatchReportingSupport.scala
@@ -9,7 +9,8 @@ import software.amazon.awssdk.services.cloudwatch.{CloudWatchAsyncClient, CloudW
 
 import java.util.concurrent.CompletableFuture
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.compat.java8.FutureConverters
+import scala.jdk.FutureConverters
+import scala.jdk.FutureConverters._
 import scala.util.{Failure, Success, Try}
 
 trait CloudWatchReportingSupport extends TestSuite {
@@ -82,7 +83,7 @@ class RealCloudWatchReporter(namespace: String,
    * @param f function to run. This must return some kind of CompletableFuture
    */
   private def loggedAsyncCall[T](f: ()=>CompletableFuture[T]) = {
-    FutureConverters.toScala(f()).onComplete(loggingAsyncHandler)
+    f().asScala.onComplete(loggingAsyncHandler)
   }
 
   private def put(metricName: String, value: Double): Unit = {

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,12 @@ dependencyOverrides ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.4.14",
   "ch.qos.logback" % "logback-core" % "1.4.14",
   "com.typesafe.akka" % "akka-http-core_2.13" % "10.5.3", //fix snyk high vuln
+  "com.typesafe.akka" % "akka-actor_2.13" % "2.8.5",
+  "com.typesafe.akka" % "akka-stream_2.13" % "2.8.5",
+  "com.typesafe.akka" % "akka-actor-typed_2.13" % "2.8.5",
+  "com.typesafe.akka" % "akka-slf4j_2.13" % "2.8.5",
+  "com.typesafe.akka" % "akka-protobuf-v3_2.13" % "2.8.5",
+  "com.typesafe.akka" % "akka-serialization-jackson_2.13" % "2.8.5",
 )
 
 testOptions ++= Seq("-u", "target/junit-test-reports").map(Tests.Argument(_))

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-feature", "-release:11")
 routesGenerator := InjectedRoutesGenerator
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, PlayAkkaHttpServer)
+  .enablePlugins(PlayScala)
   .disablePlugins(PlayNettyServer)
 
 val AwsVersion = "2.21.46"
@@ -32,13 +32,6 @@ dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.1",
   "ch.qos.logback" % "logback-classic" % "1.4.14",
   "ch.qos.logback" % "logback-core" % "1.4.14",
-  "com.typesafe.akka" % "akka-http-core_2.13" % "10.5.3", //fix snyk high vuln
-  "com.typesafe.akka" % "akka-actor_2.13" % "2.8.5",
-  "com.typesafe.akka" % "akka-stream_2.13" % "2.8.5",
-  "com.typesafe.akka" % "akka-actor-typed_2.13" % "2.8.5",
-  "com.typesafe.akka" % "akka-slf4j_2.13" % "2.8.5",
-  "com.typesafe.akka" % "akka-protobuf-v3_2.13" % "2.8.5",
-  "com.typesafe.akka" % "akka-serialization-jackson_2.13" % "2.8.5",
 )
 
 testOptions ++= Seq("-u", "target/junit-test-reports").map(Tests.Argument(_))

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "sanity-tests"
 
 version := "1.0"
 
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.13"
 
 scalacOptions ++= Seq("-feature", "-release:11")
 
@@ -15,7 +15,7 @@ lazy val root = (project in file("."))
   .enablePlugins(PlayScala, PlayAkkaHttpServer)
   .disablePlugins(PlayNettyServer)
 
-val AwsVersion = "2.21.10"
+val AwsVersion = "2.21.46"
 
 libraryDependencies ++= Seq(
   "org.quartz-scheduler" % "quartz" % "2.3.2",
@@ -23,7 +23,8 @@ libraryDependencies ++= Seq(
   ws,
   "software.amazon.awssdk" % "s3" % AwsVersion,
   "software.amazon.awssdk" % "cloudwatch" % AwsVersion,
-  "net.logstash.logback" % "logstash-logback-encoder" % "7.3"
+  "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
+  "joda-time" % "joda-time" % "2.12.7", //to fix "object joda is not a member.." error that appeared after dependency override akka-http-core_2.13
 )
 
 dependencyOverrides ++= Seq(
@@ -31,7 +32,7 @@ dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.1",
   "ch.qos.logback" % "logback-classic" % "1.4.14",
   "ch.qos.logback" % "logback-core" % "1.4.14",
-
+  "com.typesafe.akka" % "akka-http-core_2.13" % "10.5.3", //fix snyk high vuln
 )
 
 testOptions ++= Seq("-u", "target/junit-test-reports").map(Tests.Argument(_))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.2")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 
 addDependencyTreePlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.2")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.9")
 
 addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

To fix high vuln in `com.typesafe.play:play-akka-http-server_2.13@2.8.21`:
- we have upgraded play to version 3.
- made changes to code required for moving from akka to pekko.

Co-authored by @jonathonherbert 

## How to test

By running `snyk test`
And I think need to deploy on PROD and need to monitor logs

## How can we measure success?

No high vuln in the termnal when `snyk test`
And if deployed, logs should not report any errors