### PR TITLE
Bump snyk workflow to pull Java 11 for updated Play compatibility

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -15,6 +15,6 @@ jobs:
       SKIP_NODE: true
       
       
-      JAVA_VERSION: 8
+      JAVA_VERSION: 11
     secrets:
        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After the merge of https://github.com/guardian/content-api-sanity-tests/pull/130 Snyk did not update. Turned out that the Snyk workflow failed, because the workflow pulled in Java 8 which is not longer compatible with Play, causing an exception in SBT.

This PR updates the workflow to get Java 11 instead.

## How to test

You have to merge to run the workflow 🤷

## How can we measure success?

Snyk console updated to remove the high vulnerability for this repo

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
