### PR TITLE
Fix jackson library based high vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
 
 dependencyOverrides ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "2.1.0",  //this version is wanted by scalatest, which has more use for it in this project than play.
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.1",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2",
   "ch.qos.logback" % "logback-classic" % "1.4.14",
   "ch.qos.logback" % "logback-core" % "1.4.14",
 )


### PR DESCRIPTION
## What does this change?

Upgrading `com.fasterxml.jackson` s version to recommended version by Snyk.

## How to test

This should fix a high vulnerability in jackson library.
PROD deploy should not have any change and logs should looks fine.

## How can we measure success?

running `snyk test` should not list high vuln on terminal.
running `sbt run` should build and runs fine.
Will deploy on PROD and monitor logs. if all ok then good otherwise rollback.

