### PR TITLE
Bump to v2 of EnricoMi/publish-unit-test-result-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
               - target/sanity-tests_1.0_all.deb
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()  #runs even if there is a test failure
         with:
           files: junit-tests/*.xml


### PR DESCRIPTION
## What does this change?

Following an approach elsewhere (https://github.com/guardian/crier/pull/165) after seeing `You have exceeded a secondary rate limit` in [this run](https://github.com/guardian/content-api-sanity-tests/actions/runs/12184455191/job/33988383650), bumps EnricoMi/publish-unit-test-result-action to v2.

## How to test

This PR should get a ✅ .