### PR TITLE
Make output more readable in ELK

### DIFF
--- a/app/com/gu/contentapi/sanity/support/ElkFriendlyReporter.scala
+++ b/app/com/gu/contentapi/sanity/support/ElkFriendlyReporter.scala
@@ -1,0 +1,72 @@
+package com.gu.contentapi.sanity.support
+import org.scalatest.Reporter
+import org.scalatest.events.{AlertProvided, Event, LineInFile, Location, TestFailed, TestIgnored, TestStarting, TestSucceeded, TopOfClass, TopOfMethod}
+import org.slf4j.{LoggerFactory, MDC}
+
+import scala.util.Try
+
+/**
+ * This is a custom Reporter class for Scalatest which aims to give nicely parseable logs in central ELK
+ */
+class ElkFriendlyReporter extends Reporter {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  //Saves a copy of the logger context, calls the block safely and resets the context afterward
+  private def withIsolatedContext(f: =>Unit) = {
+    val backup = MDC.getCopyOfContextMap
+    try {
+      f
+    } finally  {
+      MDC.setContextMap(backup)
+    }
+  }
+
+  private def renderLocationMaybe(loc: Option[Location]) = loc match {
+    case Some(LineInFile(lineNumber, fileName, filePathname))=>
+      s"$fileName line $lineNumber"
+    case Some(TopOfClass(className))=>
+      s"Top of $className"
+    case Some(TopOfMethod(className, methodId))=>
+      s"Top of ${className}.$methodId"
+    case None=>
+      "(not provided)"
+  }
+
+  override def apply(event: Event): Unit = withIsolatedContext {
+    event match {
+      case AlertProvided(ordinal, message, nameInfo, throwable, formatter, location, payload, threadName, timeStamp) =>
+        MDC.put("threadName", threadName)
+        nameInfo.foreach(names=>{
+          MDC.put("suite", names.suiteName)
+          MDC.put("testName", names.testName.getOrElse("(not provided)"))
+        })
+        MDC.put("location", renderLocationMaybe(location))
+        logger.error(message, throwable)
+      case TestSucceeded(ordinal, suiteName, suiteId, suiteClassName, testName, testText, recordedEvents, duration, formatter, location, rerunner, payload, threadName, timeStamp)=>
+        MDC.put("threadName", threadName)
+        MDC.put("suiteName", suiteName)
+        MDC.put("class", suiteClassName.getOrElse("(not provided)"))
+        MDC.put("testName", testName)
+        MDC.put("testText", testText)
+        MDC.put("location", renderLocationMaybe(location))
+        logger.info(s"'$testName' succeeded in ${duration.map(_.toString).getOrElse("(not provided)")}ms")
+      case TestFailed(ordinal, message, suiteName, suiteId, suiteClassName, testName, testText, recordedEvents, analysis, throwable, duration, formatter, location, rerunner, payload, threadName, timeStamp)=>
+        MDC.put("threadName", threadName)
+        MDC.put("suiteName", suiteName)
+        MDC.put("class", suiteClassName.getOrElse("(not provided)"))
+        MDC.put("testName", testName)
+        MDC.put("testText", testText)
+        MDC.put("failureMessage", message)
+        MDC.put("exceptionMsg", throwable.flatMap(t=>Option(t.getMessage)).getOrElse("(not present)"))
+        MDC.put("location", renderLocationMaybe(location))
+        analysis.foreach[Unit](a=>{
+          logger.info(a)
+        })
+        logger.warn(s"'$testName' failed in ${duration.map(_.toString).getOrElse("(not provided)")}ms: $message")
+      case TestIgnored(ordinal, suiteName, suiteId, suiteClassName, testName, testText, formatter, location, payload, threadName, timeStamp)=>
+      case TestStarting(ordinal, suiteName, suiteId, suiteClassName, testName, testText, formatter, location, rerunner, payload, threadName, timeStamp)=>
+      case _=>
+        //there are loads of other events we don't need to concern ourselves with right now
+    }
+  }
+}

--- a/app/com/gu/contentapi/sanity/support/ElkFriendlyReporter.scala
+++ b/app/com/gu/contentapi/sanity/support/ElkFriendlyReporter.scala
@@ -34,7 +34,7 @@ class ElkFriendlyReporter extends Reporter {
 
   override def apply(event: Event): Unit = withIsolatedContext {
     event match {
-      case AlertProvided(ordinal, message, nameInfo, throwable, formatter, location, payload, threadName, timeStamp) =>
+      case AlertProvided(_, message, nameInfo, throwable, _, location, _, threadName, _) =>
         MDC.put("threadName", threadName)
         nameInfo.foreach(names=>{
           MDC.put("suite", names.suiteName)
@@ -42,7 +42,7 @@ class ElkFriendlyReporter extends Reporter {
         })
         MDC.put("location", renderLocationMaybe(location))
         logger.error(message, throwable)
-      case TestSucceeded(ordinal, suiteName, suiteId, suiteClassName, testName, testText, recordedEvents, duration, formatter, location, rerunner, payload, threadName, timeStamp)=>
+      case TestSucceeded(_, suiteName, _, suiteClassName, testName, testText, _, duration, _, location, _, _, threadName, _)=>
         MDC.put("threadName", threadName)
         MDC.put("suiteName", suiteName)
         MDC.put("status", "success")
@@ -51,7 +51,7 @@ class ElkFriendlyReporter extends Reporter {
         MDC.put("testText", testText)
         MDC.put("location", renderLocationMaybe(location))
         logger.info(s"'$testName' succeeded in ${duration.map(_.toString).getOrElse("(not provided)")}ms")
-      case TestFailed(ordinal, message, suiteName, suiteId, suiteClassName, testName, testText, recordedEvents, analysis, throwable, duration, formatter, location, rerunner, payload, threadName, timeStamp)=>
+      case TestFailed(_, message, suiteName, _, suiteClassName, testName, testText, _, analysis, throwable, duration, _, location, _, _, threadName, _)=>
         MDC.put("threadName", threadName)
         MDC.put("suiteName", suiteName)
         MDC.put("status", "Failed")
@@ -65,7 +65,7 @@ class ElkFriendlyReporter extends Reporter {
           logger.info(a)
         })
         logger.warn(s"'$testName' failed in ${duration.map(_.toString).getOrElse("(not provided)")}ms: $message")
-      case TestIgnored(ordinal, suiteName, suiteId, suiteClassName, testName, testText, formatter, location, payload, threadName, timeStamp)=>
+      case TestIgnored(_, suiteName, _, suiteClassName, testName, testText, _, location, _, threadName, _)=>
         MDC.put("threadName", threadName)
         MDC.put("suiteName", suiteName)
         MDC.put("status", "ignored")
@@ -74,7 +74,7 @@ class ElkFriendlyReporter extends Reporter {
         MDC.put("testText", testText)
         MDC.put("location", renderLocationMaybe(location))
         logger.info(s"'$testName' was ignored")
-      case TestStarting(ordinal, suiteName, suiteId, suiteClassName, testName, testText, formatter, location, rerunner, payload, threadName, timeStamp)=>
+      case TestStarting(_, suiteName, _, suiteClassName, testName, testText, _, location, _, _, threadName, _)=>
         MDC.put("threadName", threadName)
         MDC.put("suiteName", suiteName)
         MDC.put("logger_name", suiteClassName.getOrElse("(not provided)"))

--- a/app/com/gu/contentapi/sanity/support/ElkFriendlyReporter.scala
+++ b/app/com/gu/contentapi/sanity/support/ElkFriendlyReporter.scala
@@ -45,7 +45,8 @@ class ElkFriendlyReporter extends Reporter {
       case TestSucceeded(ordinal, suiteName, suiteId, suiteClassName, testName, testText, recordedEvents, duration, formatter, location, rerunner, payload, threadName, timeStamp)=>
         MDC.put("threadName", threadName)
         MDC.put("suiteName", suiteName)
-        MDC.put("class", suiteClassName.getOrElse("(not provided)"))
+        MDC.put("status", "success")
+        MDC.put("logger_name", suiteClassName.getOrElse("(not provided)"))
         MDC.put("testName", testName)
         MDC.put("testText", testText)
         MDC.put("location", renderLocationMaybe(location))
@@ -53,7 +54,8 @@ class ElkFriendlyReporter extends Reporter {
       case TestFailed(ordinal, message, suiteName, suiteId, suiteClassName, testName, testText, recordedEvents, analysis, throwable, duration, formatter, location, rerunner, payload, threadName, timeStamp)=>
         MDC.put("threadName", threadName)
         MDC.put("suiteName", suiteName)
-        MDC.put("class", suiteClassName.getOrElse("(not provided)"))
+        MDC.put("status", "Failed")
+        MDC.put("logger_name", suiteClassName.getOrElse("(not provided)"))
         MDC.put("testName", testName)
         MDC.put("testText", testText)
         MDC.put("failureMessage", message)
@@ -64,7 +66,22 @@ class ElkFriendlyReporter extends Reporter {
         })
         logger.warn(s"'$testName' failed in ${duration.map(_.toString).getOrElse("(not provided)")}ms: $message")
       case TestIgnored(ordinal, suiteName, suiteId, suiteClassName, testName, testText, formatter, location, payload, threadName, timeStamp)=>
+        MDC.put("threadName", threadName)
+        MDC.put("suiteName", suiteName)
+        MDC.put("status", "ignored")
+        MDC.put("logger_name", suiteClassName.getOrElse("(not provided)"))
+        MDC.put("testName", testName)
+        MDC.put("testText", testText)
+        MDC.put("location", renderLocationMaybe(location))
+        logger.info(s"'$testName' was ignored")
       case TestStarting(ordinal, suiteName, suiteId, suiteClassName, testName, testText, formatter, location, rerunner, payload, threadName, timeStamp)=>
+        MDC.put("threadName", threadName)
+        MDC.put("suiteName", suiteName)
+        MDC.put("logger_name", suiteClassName.getOrElse("(not provided)"))
+        MDC.put("testName", testName)
+        MDC.put("testText", testText)
+        MDC.put("location", renderLocationMaybe(location))
+        logger.debug(s"'$testName' starting")
       case _=>
         //there are loads of other events we don't need to concern ourselves with right now
     }

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ dependencyOverrides ++= Seq(
   "ch.qos.logback" % "logback-core" % "1.4.14",
 )
 
-testOptions ++= Seq("-u", "target/junit-test-reports").map(Tests.Argument(_))
+testOptions ++= Seq("-u", "target/junit-test-reports", "-C", "com.gu.contentapi.sanity.support.ElkFriendlyReporter").map(Tests.Argument(_))
 
 Universal / packageName := normalizedName.value
 maintainer := "Guardian Content Platforms <content-platforms.dev@theguardian.com>"

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ dependencyOverrides ++= Seq(
   "ch.qos.logback" % "logback-core" % "1.4.14",
 )
 
-testOptions ++= Seq("-u", "target/junit-test-reports", "-C", "com.gu.contentapi.sanity.support.ElkFriendlyReporter").map(Tests.Argument(_))
+testOptions ++= Seq("-u", "target/junit-test-reports").map(Tests.Argument(_))
 
 Universal / packageName := normalizedName.value
 maintainer := "Guardian Content Platforms <content-platforms.dev@theguardian.com>"

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,6 +10,7 @@
     </appender>
 
     <logger name="com.gu.contentapi.sanity" level="INFO"/>
+    <logger name="com.gu.contentapi.sanity.support.RealCloudWatchReporter" level="WARN"/>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
## What does this change?

Implements a custom Reporter for Scalatest that logs the sanity tests success/failure out through slf4j.  The upshot is that the information all comes out in JSON format which can be easily parsed and stored by central ELK.

Lots of extra information is stashed into the logging context and will be available in columns in ELK

At present, the output is a horrible mix of JSON and console text and it looks something like this in ELK:

<img width="1421" alt="Screenshot 2024-12-10 at 09 00 33" src="https://github.com/user-attachments/assets/9cec72cb-09ed-44ec-82d4-af1e8eaf8409">

Updated it comes out like this:
<img width="1421" alt="Screenshot 2024-12-10 at 09 15 40" src="https://github.com/user-attachments/assets/337cbc9c-facc-48fd-9707-0e57b51272de">

Crucially note the `status` column, allowing quick search and/or visualisation on which test are failing and when.

## How to test

Run locally.

```bash
aws s3 cp s3://content-api-config/content-api-sanity-tests/CODE/sanity-tests/content-api-sanity-tests.conf  ~/.gu/content-api-sanity-tests.conf`
export JAVA_OPTS="-Dconfig.file=/Users/{name}/.gu/content-api-sanity-tests.conf"
sbt run
```

You should see all the logs coming out in JSON format.

For bonus points, edit `logback.xml` to change this line:

```xml
<encoder class="net.logstash.logback.encoder.LogstashEncoder" />
```

to this:
```xml
<layout class="ch.qos.logback.classic.PatternLayout">
    <Pattern>
        %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
    </Pattern>
</layout>
```

and hey presto it should be readable in-console again.

## How can we measure success?

Able to debug sanity-tests issues more quickly and easily
