### PR TITLE
Upgrade OS via new AMI

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -18,6 +18,6 @@ deployments:
       amiParameter: AMISanitytests
       amiEncrypted: true
       amiTags:
-        Recipe: ubuntu-focal-capi-arm-jdk11
+        Recipe: ubuntu-jammy-capi-arm-jdk11
         AmigoStage: PROD
         BuiltBy: amigo


### PR DESCRIPTION
## What does this change?

Focal is out of support, switch to Jammy instead.

## How to test

There's no reason to think the unit tests will fail, so the real proof will be when we deploy to PROD (there's no CODE version of this). We should be able to see immediately if there's an issue because the instance will either start properly, or it won't.

## How can we measure success?

Monitor the logs. We'd expect normal behaviour to be ogoing.

## Have we considered potential risks?

Risks are minimal. We'll deploy the previous version if there are any signs of trouble and fix forward, or revert if they're significant and regroup.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A  - there are no UI changes here (there's no UI anyway!)

